### PR TITLE
refactor:Update sidebar to show menu based on login state

### DIFF
--- a/frontend/komsiluk-taxiProject/src/app/core/layout/navbar/navbar.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/navbar/navbar.component.ts
@@ -1,25 +1,29 @@
+// navbar.component.ts
+
 import { Component, EventEmitter, Output } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { Router, NavigationEnd } from '@angular/router';
 import { filter } from 'rxjs/operators';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-navbar',
   standalone: true,
   imports: [CommonModule],
   templateUrl: './navbar.component.html',
-  styleUrl: './navbar.component.css',
+  styleUrls: ['./navbar.component.css'],
 })
 export class NavbarComponent {
   @Output() menuClick = new EventEmitter<void>();
   @Output() rightMenuClick = new EventEmitter<void>();
   @Output() filterClick = new EventEmitter<void>();
+  @Output() driverHistoryChange = new EventEmitter<boolean>(); // Dodajemo EventEmitter za slanje promene
 
   isDriverHistory = false;
 
   constructor(private router: Router) {
     this.router.events.pipe(filter(e => e instanceof NavigationEnd)).subscribe(() => {
       this.isDriverHistory = this.router.url.startsWith('/driver-history');
+      this.driverHistoryChange.emit(this.isDriverHistory); // Emituj promenu isDriverHistory
     });
   }
 

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/rightsidebar.component/rightsidebar.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/rightsidebar.component/rightsidebar.component.css
@@ -54,6 +54,8 @@
   border-radius: 999px;
 }
 
+
+
 /* RESPONSIVE */
 @media (max-width: 768px) {
   .rightsidebar {

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/rightsidebar.component/rightsidebar.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/rightsidebar.component/rightsidebar.component.html
@@ -1,10 +1,19 @@
 <aside class="rightsidebar" [class.open]="open">
   <div class="rightsidebar__content">
     <nav class="rightmenu">
-      <a class="rightmenu__item rightmenu__item--active" href="#">Login</a>
-      <a class="rightmenu__item" href="#">Register</a>
+      <!-- Prikazuj samo kada korisnik nije ulogovan -->
+      <a *ngIf="!isLoggedIn" class="rightmenu__item rightmenu__item--active" href="#">Login</a>
+      <a *ngIf="!isLoggedIn" class="rightmenu__item" href="#">Register</a>
+
+      <!-- Kada je korisnik ulogovan -->
+      <a *ngIf="isLoggedIn" class="rightmenu__item rightmenu__item--active" href="#">Profile</a>
+      <a *ngIf="isLoggedIn" class="rightmenu__item" href="#">Usage report</a>
+      <a *ngIf="isLoggedIn" class="rightmenu__item" href="#">Ride history</a>
+
+
+
       <a class="rightmenu__item" href="#">Support</a>
-      <a class="rightmenu__item" href="#">About us</a>
+      <a  class="rightmenu__item" href="#">About us</a>
     </nav>
   </div>
 </aside>

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/rightsidebar.component/rightsidebar.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/rightsidebar.component/rightsidebar.component.ts
@@ -1,11 +1,26 @@
 import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router, NavigationEnd } from '@angular/router';
+import { filter } from 'rxjs/operators';
 
 @Component({
   selector: 'app-rightsidebar',
   standalone: true,
+  imports: [CommonModule],
   templateUrl: './rightsidebar.component.html',
-  styleUrl: './rightsidebar.component.css',
+  styleUrls: ['./rightsidebar.component.css'],
 })
 export class RightsidebarComponent {
   @Input() open = false;
+  isLoggedIn: boolean = false;
+  isDriverHistory: boolean = false;
+
+  constructor(private router: Router) {
+    // Ovaj kod prati promene u URL-u
+    this.router.events.pipe(filter(e => e instanceof NavigationEnd)).subscribe(() => {
+      this.isDriverHistory = this.router.url.startsWith('/driver-history');
+      // Postavljamo isLoggedIn vrednost prema URL-u
+      this.isLoggedIn = this.isDriverHistory; // Pretpostavljamo da ako je URL za driver-history, korisnik je ulogovan
+    });
+  }
 }


### PR DESCRIPTION
Modified right sidebar to display different menu items depending on whether the user is logged in. Added logic in both navbar and rightsidebar components to track and emit login state based on the current route, specifically for '/driver-history'.