### PR TITLE
feat: Add log out message page

### DIFF
--- a/frontend/komsiluk-taxiProject/src/app/features/auth/components/auth-card/auth-card.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/features/auth/components/auth-card/auth-card.component.css
@@ -19,7 +19,7 @@
 .card-title {
   font-size: var(--fs-h1);
   margin-bottom: 20px;
-  font-weight: var(--weight-medium);
+  font-weight: var(--weight-regular);
   text-transform: uppercase;
 }
 
@@ -31,6 +31,10 @@
 }
 .card-body {
   margin-block:30px;
+  font-size: var(--fs-md);
+  line-height: 1.25;
+  max-width: 360px;
+  font-weight: var(--weight-regular);
 }
 
 .card-actions {

--- a/frontend/komsiluk-taxiProject/src/app/features/auth/pages/activation-message/activation-message.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/features/auth/pages/activation-message/activation-message.component.html
@@ -1,14 +1,14 @@
-<app-auth-card title="Activation Message">
+<app-auth-card title="Verification Message">
 
-    <div>We've sent you a verification email. Please check your inbox and click the activation link.</div>
+    <div>We've sent you a verification email. Please check your inbox and click the link.</div>
 
 
     <button card-actions class="btn btn--ghost btn-scale text-semibold" [routerLink]="'/login'" type="button">
-        Cancel
+        Close
     </button>
 
     <button card-actions type="button" class="btn btn--primary btn-scale text-semibold"
         (click)="resendActivationEmail()">
-        Resend Email
+        Resend
     </button>
 </app-auth-card>

--- a/frontend/komsiluk-taxiProject/src/app/features/profile/components/profile-sidebar/profile-sidebar.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/profile/components/profile-sidebar/profile-sidebar.component.ts
@@ -19,7 +19,6 @@ export class ProfileSidebarComponent {
     this.router = rout;
   }
   logout() {
-    this.authService.logout();
-    this.router.navigate(['/']);
+    this.router.navigate(['/message', 'confirm-logout']);
   }
 }

--- a/frontend/komsiluk-taxiProject/src/app/shared/components/message-page/message-page.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/shared/components/message-page/message-page.component.css
@@ -3,43 +3,14 @@
   height: 100%;
 }
 
-.msg-screen {
-  min-height: calc(100vh - 64px); /* ispod navbara */
-  display: grid;
-  place-items: center;
-  padding: 0 16px;
-  box-sizing: border-box;
-}
-
-.msg-panel {
-  width: min(420px, 92vw);
-  padding: 22px 28px 18px;
-}
-
-.msg-title {
-  font-size: var(--fs-h1);
-  margin-bottom: 20px;
-  font-weight: var(--weight-regular);
-}
-
-.msg-divider {
-  height: 2px;
-  width: 100%;
-  background: rgba(255, 255, 255, 0.75);
-  margin-bottom: 14px;
-}
-
 .msg-text {
-  font-size: var(--fs-md);
-  line-height: 1.25;
   max-width: 360px;
-  margin-top: 30px;
-  margin-bottom: 35px;
   font-weight: var(--weight-regular);
 }
 
-.msg-actions {
-  margin-top: 25px;
+[card-actions]{
   display: flex;
   justify-content: flex-end;
+  gap: 14px;
+  flex-wrap: wrap;
 }

--- a/frontend/komsiluk-taxiProject/src/app/shared/components/message-page/message-page.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/shared/components/message-page/message-page.component.html
@@ -1,22 +1,16 @@
-<div class="app-bg-textured msg-screen">
-  <div class="glass-panel glass-panel--ep msg-panel">
-    <div class="msg-title text-semibold">{{ title }}</div>
-    <div class="msg-divider"></div>
-
-    <div class="msg-text text-medium">
-      {{ description }}
-    </div>
-
-    <div class="msg-actions">
-      <button
-        type="button"
-        class="btn btn--primary btn-scale text-semibold"
-        (click)="done()"
-      >
-        {{ buttonText }}
-      </button>
-
-      <ng-content></ng-content>
-    </div>
+<app-auth-card [title]="title">
+  <div class="msg-text text-medium">
+    {{ description }}
   </div>
-</div>
+
+  <div card-actions>
+    @for (a of actions; track a.text) {
+      <button type="button" class="btn btn-scale text-semibold"
+        [class.btn--primary]="(a.variant ?? 'primary') === 'primary'"
+        [class.btn--ghost]="(a.variant ?? 'primary') === 'ghost'"
+        (click)="run(a)">
+        {{ a.text }}
+      </button>
+    }
+  </div>
+</app-auth-card>

--- a/frontend/komsiluk-taxiProject/src/app/shared/components/message-page/message-registry.ts
+++ b/frontend/komsiluk-taxiProject/src/app/shared/components/message-page/message-registry.ts
@@ -1,15 +1,50 @@
 export type MessageId =
   | 'driver-profile-edit-submitted'
+  | 'confirm-logout';
 
-export const MESSAGE_REGISTRY: Record<
-  MessageId,
-  { title: string; description: string; doneUrl: string; buttonText?: string }
-> = {
+export type MessageAction =
+  | {
+      kind: 'navigate';
+      text: string;
+      url: string;
+      variant?: 'primary' | 'ghost';
+    }
+  | {
+      kind: 'logout';
+      text: string;
+      urlAfter: string;
+      toast?: string;
+      variant?: 'primary' | 'ghost';
+    };
+
+export type MessageConfig = {
+  title: string;
+  description: string;
+  actions: MessageAction[];
+};
+
+export const MESSAGE_REGISTRY: Record<MessageId, MessageConfig> = {
   'driver-profile-edit-submitted': {
     title: 'Profile update submitted',
     description:
       'Your profile changes have been submitted and are waiting for administrator approval. They will become visible once approved.',
-    doneUrl: '/profile',
-    buttonText: 'Done',
+    actions: [
+      { kind: 'navigate', text: 'Done', url: '/profile', variant: 'primary' },
+    ],
+  },
+
+  'confirm-logout': {
+    title: 'Log out',
+    description: 'Are you sure you want to log out?',
+    actions: [
+      { kind: 'navigate', text: 'Cancel', url: '/profile', variant: 'ghost' },
+      {
+        kind: 'logout',
+        text: 'Log out',
+        urlAfter: '/',
+        toast: 'Logged out successfully!',
+        variant: 'primary',
+      },
+    ],
   },
 };


### PR DESCRIPTION
Message page now uses AuthCard layout and supports multiple actions via a registry. Logout flow is updated to show a confirmation message instead of immediate logout, and message registry is extended to support configurable actions. UI and text improvements are made to activation and message components for consistency.