### PR TITLE
feature: Add admin user blocking feature

### DIFF
--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/beans/BlockNote.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/beans/BlockNote.java
@@ -1,0 +1,38 @@
+package rs.ac.uns.ftn.iss.Komsiluk.beans;
+
+import java.time.LocalDateTime;
+
+public class BlockNote {
+
+    private Long id;
+    private User blockedUser;
+    private User admin;
+    private String reason;
+    private LocalDateTime createdAt;
+
+    public BlockNote() {
+    }
+
+    public BlockNote(Long id, User blockedUser, User admin, String reason, LocalDateTime createdAt) {
+        this.id = id;
+        this.blockedUser = blockedUser;
+        this.admin = admin;
+        this.reason = reason;
+        this.createdAt = createdAt;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public User getBlockedUser() { return blockedUser; }
+    public void setBlockedUser(User blockedUser) { this.blockedUser = blockedUser; }
+
+    public User getAdmin() { return admin; }
+    public void setAdmin(User admin) { this.admin = admin; }
+
+    public String getReason() { return reason; }
+    public void setReason(String reason) { this.reason = reason; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/controllers/BlockNoteController.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/controllers/BlockNoteController.java
@@ -1,0 +1,35 @@
+package rs.ac.uns.ftn.iss.Komsiluk.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import rs.ac.uns.ftn.iss.Komsiluk.dtos.block.BlockNoteCreateDTO;
+import rs.ac.uns.ftn.iss.Komsiluk.dtos.block.BlockNoteResponseDTO;
+import rs.ac.uns.ftn.iss.Komsiluk.services.interfaces.IBlockNoteService;
+
+@RestController
+@RequestMapping("/api/blocks")
+public class BlockNoteController {
+
+	@Autowired
+    private IBlockNoteService blockNoteService;
+
+    @PostMapping
+    public ResponseEntity<BlockNoteResponseDTO> create(@RequestBody BlockNoteCreateDTO dto) {
+        BlockNoteResponseDTO created = blockNoteService.createBlock(dto);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<BlockNoteResponseDTO> getForUser(@PathVariable Long userId) {
+        BlockNoteResponseDTO responseDTO = blockNoteService.getLastBlockForUser(userId);
+        return new ResponseEntity<>(responseDTO, HttpStatus.OK);
+    }
+}

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/controllers/UserController.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/controllers/UserController.java
@@ -1,5 +1,7 @@
 package rs.ac.uns.ftn.iss.Komsiluk.controllers;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -8,8 +10,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import rs.ac.uns.ftn.iss.Komsiluk.dtos.user.UserBlockedDTO;
 import rs.ac.uns.ftn.iss.Komsiluk.dtos.user.UserChangePasswordDTO;
 import rs.ac.uns.ftn.iss.Komsiluk.dtos.user.UserProfileResponseDTO;
 import rs.ac.uns.ftn.iss.Komsiluk.dtos.user.UserProfileUpdateDTO;
@@ -38,5 +42,19 @@ public class UserController {
     public ResponseEntity<Void> changePassword(@PathVariable Long id, @RequestBody UserChangePasswordDTO dto) {
         userService.changePassword(id, dto);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+    
+    @GetMapping("/emails/autocomplete")
+    public ResponseEntity<List<String>> autocompleteEmails(@RequestParam(name = "query", required = false, defaultValue = "") String query, @RequestParam(name = "limit", required = false, defaultValue = "10") int limit) {
+        List<String> emails = userService.autocompleteEmails(query, limit);
+        return new ResponseEntity<>(emails, HttpStatus.OK);
+    }
+    
+    @GetMapping("/{id}/blocked")
+    public ResponseEntity<UserBlockedDTO> isUserBlocked(@PathVariable Long id) {
+        boolean blocked = userService.isBlocked(id);
+        UserBlockedDTO dto = new UserBlockedDTO();
+        dto.setBlocked(blocked);
+        return ResponseEntity.ok(dto);
     }
 }

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/dtos/block/BlockNoteCreateDTO.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/dtos/block/BlockNoteCreateDTO.java
@@ -1,0 +1,19 @@
+package rs.ac.uns.ftn.iss.Komsiluk.dtos.block;
+
+public class BlockNoteCreateDTO {
+	
+    private String blockedUserEmail;
+    private long adminId;
+    private String reason;
+
+    public BlockNoteCreateDTO() {}
+
+    public String getBlockedUserEmail() { return blockedUserEmail; }
+    public void setBlockedUserEmail(String blockedUserEmail) { this.blockedUserEmail = blockedUserEmail; }
+
+    public long getAdminId() { return adminId; }
+    public void setAdminId(long adminId) { this.adminId = adminId; }
+
+    public String getReason() { return reason; }
+    public void setReason(String reason) { this.reason = reason; }
+}

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/dtos/block/BlockNoteResponseDTO.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/dtos/block/BlockNoteResponseDTO.java
@@ -1,0 +1,29 @@
+package rs.ac.uns.ftn.iss.Komsiluk.dtos.block;
+
+import java.time.LocalDateTime;
+
+public class BlockNoteResponseDTO {
+	
+    private Long id;
+    private String blockedUserEmail;
+    private String adminEmail;
+    private String reason;
+    private LocalDateTime createdAt;
+
+    public BlockNoteResponseDTO() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getBlockedUserEmail() { return blockedUserEmail; }
+    public void setBlockedUserEmail(String blockedUserEmail) { this.blockedUserEmail = blockedUserEmail; }
+
+    public String getAdminEmail() { return adminEmail; }
+    public void setAdminEmail(String adminEmail) { this.adminEmail = adminEmail; }
+
+    public String getReason() { return reason; }
+    public void setReason(String reason) { this.reason = reason; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/dtos/user/UserBlockedDTO.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/dtos/user/UserBlockedDTO.java
@@ -1,0 +1,16 @@
+package rs.ac.uns.ftn.iss.Komsiluk.dtos.user;
+
+public class UserBlockedDTO {
+    private boolean blocked;
+
+    public UserBlockedDTO() {
+    }
+
+    public boolean isBlocked() {
+        return blocked;
+    }
+
+    public void setBlocked(boolean blocked) {
+        this.blocked = blocked;
+    }
+}

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/mappers/BlockNoteDTOMapper.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/mappers/BlockNoteDTOMapper.java
@@ -1,0 +1,27 @@
+package rs.ac.uns.ftn.iss.Komsiluk.mappers;
+
+import org.springframework.stereotype.Component;
+
+import rs.ac.uns.ftn.iss.Komsiluk.beans.BlockNote;
+import rs.ac.uns.ftn.iss.Komsiluk.dtos.block.BlockNoteResponseDTO;
+
+@Component
+public class BlockNoteDTOMapper {
+
+	public BlockNoteResponseDTO toResponseDTO(BlockNote node) {
+        BlockNoteResponseDTO dto = new BlockNoteResponseDTO();
+        dto.setId(node.getId());
+        dto.setReason(node.getReason());
+        dto.setCreatedAt(node.getCreatedAt());
+
+        if (node.getBlockedUser() != null) {
+            dto.setBlockedUserEmail(node.getBlockedUser().getEmail());
+        }
+
+        if (node.getAdmin() != null) {
+            dto.setAdminEmail(node.getAdmin().getEmail());
+        }
+
+        return dto;
+    }
+}

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/repositories/BlockNoteRepository.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/repositories/BlockNoteRepository.java
@@ -1,0 +1,41 @@
+package rs.ac.uns.ftn.iss.Komsiluk.repositories;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Repository;
+
+import rs.ac.uns.ftn.iss.Komsiluk.beans.BlockNote;
+
+@Repository
+public class BlockNoteRepository {
+
+    private final Map<Long, BlockNote> storage = new HashMap<>();
+    private final AtomicLong idGen = new AtomicLong(1);
+
+    public BlockNote save(BlockNote node) {
+        if (node.getId() == null) {
+            node.setId(idGen.getAndIncrement());
+        }
+        storage.put(node.getId(), node);
+        return node;
+    }
+
+    public List<BlockNote> findAll() {
+        return new ArrayList<>(storage.values());
+    }
+
+    public List<BlockNote> findByBlockedUserId(Long userId) {
+        if (userId == null) return Collections.emptyList();
+
+        return storage.values().stream()
+                .filter(b -> b.getBlockedUser() != null
+                        && userId.equals(b.getBlockedUser().getId()))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/BlockNoteService.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/BlockNoteService.java
@@ -1,0 +1,56 @@
+package rs.ac.uns.ftn.iss.Komsiluk.services;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import rs.ac.uns.ftn.iss.Komsiluk.beans.BlockNote;
+import rs.ac.uns.ftn.iss.Komsiluk.beans.User;
+import rs.ac.uns.ftn.iss.Komsiluk.dtos.block.BlockNoteCreateDTO;
+import rs.ac.uns.ftn.iss.Komsiluk.dtos.block.BlockNoteResponseDTO;
+import rs.ac.uns.ftn.iss.Komsiluk.mappers.BlockNoteDTOMapper;
+import rs.ac.uns.ftn.iss.Komsiluk.repositories.BlockNoteRepository;
+import rs.ac.uns.ftn.iss.Komsiluk.repositories.UserRepository;
+import rs.ac.uns.ftn.iss.Komsiluk.services.interfaces.IBlockNoteService;
+
+@Service
+public class BlockNoteService implements IBlockNoteService {
+
+	@Autowired
+    private BlockNoteRepository blockNoteRepository;
+	@Autowired
+    private UserRepository userRepository;
+	@Autowired
+    private BlockNoteDTOMapper mapper;
+
+    @Override
+    public BlockNoteResponseDTO createBlock(BlockNoteCreateDTO dto) {
+    	
+        User blocked = userRepository.findByEmail(dto.getBlockedUserEmail());
+
+        User admin = userRepository.findById(dto.getAdminId());
+
+        blocked.setBlocked(true);
+        userRepository.save(blocked);
+
+        BlockNote node = new BlockNote();
+        node.setBlockedUser(blocked);
+        node.setAdmin(admin);
+        node.setReason(dto.getReason());
+        node.setCreatedAt(LocalDateTime.now());
+
+        node = blockNoteRepository.save(node);
+
+        return mapper.toResponseDTO(node);
+    }
+
+    @Override
+    public BlockNoteResponseDTO getLastBlockForUser(Long userId) {
+        List<BlockNote> list = blockNoteRepository.findByBlockedUserId(userId);
+
+        return list.stream().max(Comparator.comparing(BlockNote::getCreatedAt)).map(mapper::toResponseDTO).orElse(null);
+    }
+}

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/exceptions/ActivationAlreadySentException.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/exceptions/ActivationAlreadySentException.java
@@ -5,8 +5,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(HttpStatus.TOO_MANY_REQUESTS)
 public class ActivationAlreadySentException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
 
-    public ActivationAlreadySentException() {
+	public ActivationAlreadySentException() {
         super("Activation email already sent. Please check your inbox.");
     }
 }

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/interfaces/IBlockNoteService.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/interfaces/IBlockNoteService.java
@@ -1,0 +1,11 @@
+package rs.ac.uns.ftn.iss.Komsiluk.services.interfaces;
+
+import rs.ac.uns.ftn.iss.Komsiluk.dtos.block.BlockNoteCreateDTO;
+import rs.ac.uns.ftn.iss.Komsiluk.dtos.block.BlockNoteResponseDTO;
+
+public interface IBlockNoteService {
+
+    public BlockNoteResponseDTO createBlock(BlockNoteCreateDTO dto);
+
+    public BlockNoteResponseDTO getLastBlockForUser(Long userId);
+}

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/interfaces/IUserService.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/interfaces/IUserService.java
@@ -1,6 +1,7 @@
 package rs.ac.uns.ftn.iss.Komsiluk.services.interfaces;
 
 import java.util.Collection;
+import java.util.List;
 
 import rs.ac.uns.ftn.iss.Komsiluk.beans.User;
 import rs.ac.uns.ftn.iss.Komsiluk.dtos.user.UserChangePasswordDTO;
@@ -26,4 +27,8 @@ public interface IUserService {
     public void resetPassword(Long userId, String newPassword);
 
     public User findByEmail(String email);
+    
+    public List<String> autocompleteEmails(String query, int limit);
+    
+    public boolean isBlocked(Long userId);
 }

--- a/frontend/komsiluk-taxiProject/src/app/app.html
+++ b/frontend/komsiluk-taxiProject/src/app/app.html
@@ -66,3 +66,16 @@
   (close)="schedDetailsModal.close()"
   (cancelRide)="onScheduledCancelRide($event)">
 </app-scheduled-details-dialog>
+
+<app-block-user-confirm-dialog
+  [open]="blockUserModal.open()"
+  [email]="blockUserModal.data()?.email ?? ''"
+  (cancel)="blockUserModal.close()"
+  (confirm)="blockUserModal.confirm($event)">
+</app-block-user-confirm-dialog>
+
+<app-account-blocked-dialog
+  [open]="blockedModal.open()"
+  [data]="blockedModal.data()"
+  (closed)="blockedModal.close()">
+</app-account-blocked-dialog>

--- a/frontend/komsiluk-taxiProject/src/app/app.ts
+++ b/frontend/komsiluk-taxiProject/src/app/app.ts
@@ -27,6 +27,10 @@ import { FavoriteRouteService } from './core/layout/components/passenger/favorit
 import { FavoritesBusService } from './core/layout/components/passenger/favorite/services/favorites-bus.service';
 import { ScheduledDetailsDialogComponent } from './core/layout/components/passenger/scheduled/scheduled-details-dialog/scheduled-details-dialog.component';
 import { ScheduledDetailsModalService } from './shared/components/modal-shell/services/scheduled-details-modal.service';
+import { BlockUserConfirmDialogComponent } from './core/layout/components/admin/block/block-user-confirm-dialog/block-user-confirm-dialog.component';
+import { BlockUserConfirmModalService } from './shared/components/modal-shell/services/block-user-confirm-modal.service';
+import { AccountBlockedDialogComponent } from './core/layout/components/passenger/book_ride/account-blocked-dialog/account-blocked-dialog.component';
+import { AccountBlockedModalService } from './shared/components/modal-shell/services/account-blocked-modal.service';
 
 @Component({
   selector: 'app-root',
@@ -44,7 +48,9 @@ import { ScheduledDetailsModalService } from './shared/components/modal-shell/se
     FavoriteDetailsDialogComponent,
     RenameFavoriteDialogComponent,
     DeleteFavoriteDialogComponent,
-    ScheduledDetailsDialogComponent
+    ScheduledDetailsDialogComponent,
+    BlockUserConfirmDialogComponent,
+    AccountBlockedDialogComponent
   ],
   templateUrl: './app.html',
   styleUrl: './app.css'
@@ -57,14 +63,17 @@ export class App implements OnInit {
 
   constructor(public filterSvc: RideHistoryFilterService, private router: Router, public confirmModal: ConfirmBookingModalService,
     public addFavModal: AddFavoriteModalService, public favDetailsModal: FavoriteDetailsModalService, public renameFavModal: RenameFavoriteModalService,
-    public deleteFavModal: DeleteFavoriteModalService, public toastService: ToastService, private favoriteApi: FavoriteRouteService, private favBus: FavoritesBusService, public schedDetailsModal: ScheduledDetailsModalService) {}
+    public deleteFavModal: DeleteFavoriteModalService, public toastService: ToastService, private favoriteApi: FavoriteRouteService, private favBus: FavoritesBusService,
+    public schedDetailsModal: ScheduledDetailsModalService, public blockUserModal: BlockUserConfirmModalService, public blockedModal: AccountBlockedModalService) {}
 
   ngOnInit(): void {
-  this.router.events
+    this.router.events
     .pipe(filter(e => e instanceof NavigationStart))
     .subscribe(() => {
-      this.isLeftSidebarOpen = false;
-      this.rightOpen = false;
+      queueMicrotask(() => {
+        this.isLeftSidebarOpen = false;
+        this.rightOpen = false;
+      });
     });
   }
 

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/admin-left-menu/admin-left-menu.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/admin-left-menu/admin-left-menu.component.css
@@ -1,0 +1,61 @@
+.p-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.p-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  background: transparent;
+  border: none;
+  cursor: pointer;
+
+  padding: 10px 8px;
+  border-radius: 10px;
+
+  color: var(--color-white);
+}
+
+.p-item:hover {
+  background: rgba(255, 238, 2, 0.08);
+}
+
+.p-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.material-symbols-outlined{
+  color: var(--color-secondary);
+  line-height: 1;
+}
+
+.p-text {
+  font-weight: var(--weight-semi-bold);
+}
+
+.p-chev {
+  display: inline-block;
+  transition: transform 0.2s ease;
+  opacity: 0.9;
+}
+
+.p-chev--open {
+  transform: rotate(180deg);
+}
+
+.p-panel {
+  margin-left: 17px;
+  padding: 6px 8px 10px;
+  border-left: 2px solid rgba(255, 238, 2, 0.25);
+}
+
+.p-panel__label {
+  color: var(--color-secondary);
+  font-size: var(--fs-md)
+}

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/admin-left-menu/admin-left-menu.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/admin-left-menu/admin-left-menu.component.html
@@ -1,0 +1,33 @@
+<nav class="p-menu">
+
+  <!-- Check a ride -->
+  <button class="p-item" type="button" (click)="toggle('check')">
+    <span class="p-left">
+      <span class="material-symbols-outlined">fact_check</span>
+      <span class="p-text">Check a ride</span>
+    </span>
+    <span class="p-chev" [class.p-chev--open]="checkOpen()">▾</span>
+  </button>
+
+  @if (checkOpen()) {
+    <div class="p-panel">
+      <span class="p-panel__label">TODO: check ride panel</span>
+    </div>
+  }
+
+  <!-- Block a user -->
+  <button class="p-item" type="button" (click)="toggle('block')">
+    <span class="p-left">
+      <span class="material-symbols-outlined">person_off</span>
+      <span class="p-text">Block a user</span>
+    </span>
+    <span class="p-chev" [class.p-chev--open]="blockOpen()">▾</span>
+  </button>
+
+  @if (blockOpen()) {
+    <div class="p-panel">
+      <app-admin-block-user-panel />
+    </div>
+  }
+
+</nav>

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/admin-left-menu/admin-left-menu.component.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/admin-left-menu/admin-left-menu.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminLeftMenuComponent } from './admin-left-menu.component';
+
+describe('AdminLeftMenuComponent', () => {
+  let component: AdminLeftMenuComponent;
+  let fixture: ComponentFixture<AdminLeftMenuComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminLeftMenuComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AdminLeftMenuComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/admin-left-menu/admin-left-menu.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/admin-left-menu/admin-left-menu.component.ts
@@ -1,0 +1,20 @@
+import { Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AdminBlockUserPanelComponent } from '../block/admin-block-user-panel/admin-block-user-panel.component';
+
+@Component({
+  selector: 'app-admin-left-menu',
+  standalone: true,
+  imports: [CommonModule, AdminBlockUserPanelComponent],
+  templateUrl: './admin-left-menu.component.html',
+  styleUrl: './admin-left-menu.component.css',
+})
+export class AdminLeftMenuComponent {
+  checkOpen = signal(false);
+  blockOpen = signal(false);
+
+  toggle(which: 'check' | 'block') {
+    if (which === 'check') this.checkOpen.set(!this.checkOpen());
+    if (which === 'block') this.blockOpen.set(!this.blockOpen());
+  }
+}

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/admin-block-user-panel/admin-block-user-panel.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/admin-block-user-panel/admin-block-user-panel.component.css
@@ -1,0 +1,59 @@
+.au { position: relative; }
+
+.au-label{
+  color: rgba(255,255,255,0.85);
+  font-size: 12px;
+  margin-bottom: 6px;
+}
+
+.au-input{
+  width: 90%;
+  height: 28px;
+  border-radius: 2px;
+  border: 1px solid rgba(255,255,255,0.25);
+  background: #fff;
+  color: #000;
+  padding: 0 10px;
+}
+
+.au-hint{
+  margin-top: 6px;
+  color: rgba(255,255,255,0.75);
+  font-size: 12px;
+}
+
+.au-suggest{
+  margin-top: 6px;
+  background: #fff;
+  border: 3px solid var(--color-secondary);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.au-suggest__item{
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: #111;
+}
+
+.au-suggest__item:hover{
+  background: rgba(255, 238, 2, 0.15);
+}
+
+.au-btn{
+  margin-top: 25px;
+  width: 120px;
+  margin-left: 65px;
+  font-size: var(--fs-lg);
+  height: 40px;
+}
+
+.au-btn--disabled {
+  opacity: 0.55;
+  filter: grayscale(0.2);
+}

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/admin-block-user-panel/admin-block-user-panel.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/admin-block-user-panel/admin-block-user-panel.component.html
@@ -1,0 +1,38 @@
+<div class="au">
+
+  <div class="au-label text-regular">User</div>
+
+  <div class="au-input-wrap">
+    <input
+      class="au-input text-medium"
+      type="text"
+      placeholder="Please enter an email..."
+      [formControl]="emailCtrl"
+      autocomplete="off"
+    />
+  </div>
+
+  @if (loading()) {
+    <div class="au-hint text-regular">Loading...</div>
+  }
+
+  @if (suggestions().length) {
+    <div class="au-suggest">
+      @for (s of suggestions(); track s.email) {
+        <button type="button" class="au-suggest__item" (click)="pickEmail(s.email)">
+            {{ s.email }}
+        </button>
+        }
+    </div>
+  }
+
+  <button
+    class="au-btn btn btn--primary text-semibold btn-scale"
+    [class.au-btn--disabled]="!canBlock() || blocking()"
+    [disabled]="!canBlock() || blocking()"
+    type="button"
+    (click)="onBlockClick()">
+    Block
+  </button>
+
+</div>

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/admin-block-user-panel/admin-block-user-panel.component.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/admin-block-user-panel/admin-block-user-panel.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminBlockUserPanelComponent } from './admin-block-user-panel.component';
+
+describe('AdminBlockUserPanelComponent', () => {
+  let component: AdminBlockUserPanelComponent;
+  let fixture: ComponentFixture<AdminBlockUserPanelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminBlockUserPanelComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AdminBlockUserPanelComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/admin-block-user-panel/admin-block-user-panel.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/admin-block-user-panel/admin-block-user-panel.component.ts
@@ -1,0 +1,156 @@
+import { Component, OnDestroy, signal} from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { debounceTime, distinctUntilChanged, switchMap, catchError, of, Subscription, tap } from 'rxjs';
+import { ToastService } from '../../../../../../shared/components/toast/toast.service';
+import { BlockUserConfirmModalService } from '../../../../../../shared/components/modal-shell/services/block-user-confirm-modal.service';
+import { AdminUserService } from '../services/admin-user.service';
+import { finalize } from 'rxjs/operators';
+import { BlockNoteService } from '../services/block-note.service';
+import { AuthService } from '../../../../../auth/services/auth.service';
+import { BlockNoteCreateDTO } from '../../../../../../shared/models/block-note.model';
+import { HttpErrorResponse } from '@angular/common/http';
+
+type EmailSuggestion = { email: string; display: string };
+
+@Component({
+  selector: 'app-admin-block-user-panel',
+  standalone: true,
+  imports: [ReactiveFormsModule],
+  templateUrl: './admin-block-user-panel.component.html',
+  styleUrl: './admin-block-user-panel.component.css'
+})
+export class AdminBlockUserPanelComponent implements OnDestroy {
+  emailCtrl = new FormControl<string>('', { nonNullable: true });
+
+  suggestions = signal<EmailSuggestion[]>([]);
+  loading = signal(false);
+  blocking = signal(false);
+
+  private sub?: Subscription;
+
+  private pickedEmail: string | null = null;
+  pickedFromAutocomplete = false;
+
+  constructor(
+    private api: AdminUserService,
+    private toast: ToastService,
+    private blockModal: BlockUserConfirmModalService,
+    private blockNoteApi: BlockNoteService,
+    private auth: AuthService
+  ) {
+    this.sub = this.emailCtrl.valueChanges.pipe(
+      tap(v => {
+        const txt = (v ?? '').trim();
+
+        if (!this.pickedEmail || txt !== this.pickedEmail) {
+          this.pickedFromAutocomplete = false;
+        }
+      }),
+      debounceTime(250),
+      distinctUntilChanged(),
+      switchMap(v => {
+        const q = (v ?? '').trim();
+
+        if (this.pickedFromAutocomplete && this.pickedEmail && q === this.pickedEmail) {
+          this.loading.set(false);
+          this.suggestions.set([]);
+          return of<string[]>([]);
+        }
+
+        if (q.length < 2) {
+          this.loading.set(false);
+          this.suggestions.set([]);
+          return of<string[]>([]);
+        }
+
+        this.loading.set(true);
+        return this.api.autocompleteEmails(q, 8).pipe(
+          catchError(() => of<string[]>([])),
+          finalize(() => this.loading.set(false))
+        );
+      })
+    ).subscribe(list => {
+      const current = (this.emailCtrl.value ?? '').trim();
+      if (this.pickedFromAutocomplete && this.pickedEmail && current === this.pickedEmail) return;
+
+      const cleaned = (list ?? [])
+        .map(x => String(x).trim())
+        .filter(Boolean)
+        .map(email => ({ email, display: email } as EmailSuggestion));
+
+      this.suggestions.set(cleaned);
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
+
+  pickEmail(em: string) {
+    const email = (em ?? '').trim();
+    if (!email) return;
+
+    this.pickedEmail = email;
+    this.pickedFromAutocomplete = true;
+
+    this.emailCtrl.setValue(email, { emitEvent: false });
+
+    this.loading.set(false);
+    this.suggestions.set([]);
+  }
+
+  canBlock(): boolean {
+    return this.pickedFromAutocomplete && !!this.pickedEmail;
+  }
+
+  onBlockClick() {
+    if (!this.canBlock()) {
+      this.toast.show('Please select an email from autocomplete.');
+      return;
+    }
+
+    const email = this.pickedEmail!;
+    const adminId = this.auth.userId();
+
+    if (!adminId) {
+      this.toast.show('Not logged in.');
+      return;
+    }
+
+    this.blockModal.openModal({ email }, (reason) => {
+      const dto: BlockNoteCreateDTO = {
+        blockedUserEmail: email,
+        adminId: Number(adminId),
+        reason: String(reason ?? '').trim(),
+      };
+
+      if (!dto.reason) {
+        this.toast.show('Please enter a reason.');
+        return;
+      }
+
+      this.blocking.set(true);
+
+      this.blockNoteApi.create(dto).pipe(
+        finalize(() => this.blocking.set(false))
+      ).subscribe({
+        next: () => {
+          this.toast.show('User blocked successfully.');
+
+          this.pickedEmail = null;
+          this.pickedFromAutocomplete = false;
+          this.emailCtrl.setValue('', { emitEvent: false });
+          this.suggestions.set([]);
+        },
+        error: (err: HttpErrorResponse) => {
+          const msg =
+            err?.error?.message ||
+            err?.error ||
+            err?.message ||
+            'Failed to block user.';
+          this.toast.show(String(msg));
+        }
+      });
+    });
+  }
+}

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/block-user-confirm-dialog/block-user-confirm-dialog.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/block-user-confirm-dialog/block-user-confirm-dialog.component.css
@@ -1,0 +1,46 @@
+.bu-title{
+  font-size: var(--fs-h1);
+  margin-bottom: 20px;
+  color: var(--color-white);
+}
+
+.bu-sub{
+  margin-bottom: 16px;
+  font-size: var(--fs-md);
+  color: var(--color-white);
+  line-height: 1.35;
+}
+
+.bu-accent{
+  color: var(--color-secondary);
+}
+
+.bu-block{
+  margin-bottom: 8px;
+  font-size: var(--fs-md);
+  color: var(--color-white);
+}
+
+.bu-textarea{
+  width: 95%;
+  min-height: 90px;
+
+  border-radius: 2px;
+  border: 1px solid rgba(255,255,255,0.25);
+
+  background: var(--color-white);
+  color: #000;
+
+  resize: none;
+  padding: 8px 10px;
+  outline: none;
+
+  margin-bottom: 18px;
+}
+
+.bu-actions{
+  display: flex;
+  justify-content: center;
+  gap: 100px;
+  margin-top: 10px;
+}

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/block-user-confirm-dialog/block-user-confirm-dialog.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/block-user-confirm-dialog/block-user-confirm-dialog.component.html
@@ -1,0 +1,32 @@
+<app-modal-shell [open]="open" (closed)="cancel.emit()">
+
+  <div class="bu-title text-regular">Block a user</div>
+
+  <div class="bu-sub text-regular">
+    Are you sure you want to block the user:
+    <span class="bu-accent">{{ email }}</span>
+  </div>
+
+  <div class="bu-block text-regular">Please give a reason:</div>
+
+  <textarea
+    class="bu-textarea text-medium"
+    [formControl]="reasonCtrl"
+    rows="4"
+  ></textarea>
+
+  <div class="bu-actions">
+    <button type="button" class="btn btn--ghost text-semibold btn-scale" (click)="cancel.emit()">
+      Cancel
+    </button>
+
+    <button
+      type="button"
+      class="btn btn--primary text-semibold btn-scale"
+      [disabled]="reasonCtrl.invalid"
+      (click)="onConfirmClick()">
+      Confirm
+    </button>
+  </div>
+
+</app-modal-shell>

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/block-user-confirm-dialog/block-user-confirm-dialog.component.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/block-user-confirm-dialog/block-user-confirm-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BlockUserConfirmDialogComponent } from './block-user-confirm-dialog.component';
+
+describe('BlockUserConfirmDialogComponent', () => {
+  let component: BlockUserConfirmDialogComponent;
+  let fixture: ComponentFixture<BlockUserConfirmDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BlockUserConfirmDialogComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(BlockUserConfirmDialogComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/block-user-confirm-dialog/block-user-confirm-dialog.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/block-user-confirm-dialog/block-user-confirm-dialog.component.ts
@@ -1,0 +1,39 @@
+import { Component, EventEmitter, Input, Output, SimpleChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ModalShellComponent } from '../../../../../../shared/components/modal-shell/modal-shell.component';
+
+@Component({
+  selector: 'app-block-user-confirm-dialog',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, ModalShellComponent],
+  templateUrl: './block-user-confirm-dialog.component.html',
+  styleUrl: './block-user-confirm-dialog.component.css',
+})
+export class BlockUserConfirmDialogComponent {
+  @Input() open = false;
+  @Input() email = '';
+
+  @Output() cancel = new EventEmitter<void>();
+  @Output() confirm = new EventEmitter<string>();
+
+  constructor() {}
+
+  reasonCtrl = new FormControl<string>('', {
+    nonNullable: true,
+    validators: [Validators.required, Validators.minLength(3)],
+  });
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['open']?.currentValue === true) {
+      this.reasonCtrl.setValue('');
+      this.reasonCtrl.markAsPristine();
+      this.reasonCtrl.markAsUntouched();
+    }
+  }
+
+  onConfirmClick() {
+    if (this.reasonCtrl.invalid) return;
+    this.confirm.emit(this.reasonCtrl.value.trim());
+  }
+}

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/services/admin-user.service.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/services/admin-user.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AdminUserService } from './admin-user.service';
+
+describe('AdminUserService', () => {
+  let service: AdminUserService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AdminUserService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/services/admin-user.service.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/services/admin-user.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class AdminUserService {
+  private readonly API = 'http://localhost:8081/api/users';
+
+  constructor(private http: HttpClient) {}
+
+  autocompleteEmails(query: string, limit = 8): Observable<string[]> {
+    const params = new HttpParams()
+      .set('query', query ?? '')
+      .set('limit', String(limit));
+
+    return this.http.get<string[]>(`${this.API}/emails/autocomplete`, { params });
+  }
+}

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/services/block-note.service.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/services/block-note.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { BlockNoteService } from './block-note.service';
+
+describe('BlockNoteService', () => {
+  let service: BlockNoteService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BlockNoteService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/services/block-note.service.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/admin/block/services/block-note.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { BlockNoteCreateDTO, BlockNoteResponseDTO } from '../../../../../../shared/models/block-note.model';
+
+@Injectable({ providedIn: 'root' })
+export class BlockNoteService {
+  private readonly API = 'http://localhost:8081/api/blocks';
+
+  constructor(private http: HttpClient) {}
+
+  create(dto: BlockNoteCreateDTO): Observable<BlockNoteResponseDTO> {
+    return this.http.post<BlockNoteResponseDTO>(this.API, dto);
+  }
+
+  getLastForUser(userId: number): Observable<BlockNoteResponseDTO> {
+    return this.http.get<BlockNoteResponseDTO>(`${this.API}/user/${userId}`);
+  }
+}

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/passenger/book_ride/account-blocked-dialog/account-blocked-dialog.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/passenger/book_ride/account-blocked-dialog/account-blocked-dialog.component.css
@@ -1,0 +1,62 @@
+.ab-title{
+  font-size: var(--fs-h1);
+  margin-bottom: 18px;
+  color: var(--color-white);
+}
+
+.ab-sub{
+  font-size: var(--fs-md);
+  color: rgba(255,255,255,0.82);
+  margin-bottom: 18px;
+}
+
+.ab-label{
+  font-size: var(--fs-md);
+  color: rgba(255, 238, 2, 0.85);
+  margin-bottom: 8px;
+}
+
+.ab-reason{
+  border: 1px solid rgba(255, 238, 2, 0.35);
+  background: rgba(0,0,0,0.25);
+  padding: 10px 12px;
+  border-radius: 6px;
+  margin-bottom: 14px;
+}
+
+.ab-reason__text{
+  color: rgba(255,255,255,0.9);
+  font-style: italic;
+}
+
+.ab-reason__muted{
+  color: rgba(255,255,255,0.55);
+  font-style: italic;
+}
+
+.ab-meta{
+  margin-top: 8px;
+  font-size: 12px;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.ab-meta__k{
+  color: rgba(255,255,255,0.65);
+}
+
+.ab-meta__v{
+  color: var(--color-secondary);
+}
+
+.ab-foot{
+  font-size: 12px;
+  color: rgba(255,255,255,0.7);
+}
+
+.ab-actions{
+  margin-top: 18px;
+  display: flex;
+  justify-content: flex-end;
+}

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/passenger/book_ride/account-blocked-dialog/account-blocked-dialog.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/passenger/book_ride/account-blocked-dialog/account-blocked-dialog.component.html
@@ -1,0 +1,35 @@
+<app-modal-shell [open]="open" (closed)="closed.emit()">
+
+  <div class="ab-title text-regular">Account blocked</div>
+
+  <div class="ab-sub text-regular">
+    You can't book new rides at the moment because your account has been blocked by an administrator.
+  </div>
+
+  <div class="ab-label text-regular">Reason from administrator:</div>
+
+  <div class="ab-reason text-regular">
+    @if (data?.reason) {
+      <span class="ab-reason__text">{{ data?.reason }}</span>
+    } @else {
+      <span class="ab-reason__muted">No reason provided.</span>
+    }
+    @if (data?.adminEmail) {
+      <div class="ab-meta text-regular">
+        <span class="ab-meta__k">Admin:</span>
+        <span class="ab-meta__v">{{ data?.adminEmail }}</span>
+      </div>
+    }
+  </div>
+
+  <div class="ab-foot text-regular">
+    If you believe this is a mistake, please contact support.
+  </div>
+
+  <div class="ab-actions">
+    <button type="button" class="btn btn--primary text-semibold btn-scale" (click)="closed.emit()">
+      Confirm
+    </button>
+  </div>
+
+</app-modal-shell>

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/passenger/book_ride/account-blocked-dialog/account-blocked-dialog.component.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/passenger/book_ride/account-blocked-dialog/account-blocked-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AccountBlockedDialogComponent } from './account-blocked-dialog.component';
+
+describe('AccountBlockedDialogComponent', () => {
+  let component: AccountBlockedDialogComponent;
+  let fixture: ComponentFixture<AccountBlockedDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AccountBlockedDialogComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AccountBlockedDialogComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/passenger/book_ride/account-blocked-dialog/account-blocked-dialog.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/passenger/book_ride/account-blocked-dialog/account-blocked-dialog.component.ts
@@ -1,0 +1,18 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ModalShellComponent } from '../../../../../../shared/components/modal-shell/modal-shell.component';
+import { AccountBlockedModalData } from '../../../../../../shared/components/modal-shell/services/account-blocked-modal.service';
+
+@Component({
+  selector: 'app-account-blocked-dialog',
+  standalone: true,
+  imports: [CommonModule, ModalShellComponent],
+  templateUrl: './account-blocked-dialog.component.html',
+  styleUrl: './account-blocked-dialog.component.css',
+})
+export class AccountBlockedDialogComponent {
+  @Input() open = false;
+  @Input() data: AccountBlockedModalData | null = null;
+
+  @Output() closed = new EventEmitter<void>();
+}

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/leftsidebar/leftsidebar.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/leftsidebar/leftsidebar.component.html
@@ -38,6 +38,10 @@
       {
         <app-passenger-left-menu></app-passenger-left-menu>
       }
+      @else if (userRole() === UserRole.ADMIN)
+      {
+        <app-admin-left-menu></app-admin-left-menu>
+      }
       @else
       {
         <div>

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/leftsidebar/leftsidebar.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/leftsidebar/leftsidebar.component.ts
@@ -2,11 +2,12 @@ import { Component, Input, Signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AuthService, UserRole } from '../../../core/auth/services/auth.service';
 import { PassengerLeftMenuComponent } from '../components/passenger/passenger-left-menu/passenger-left-menu.component';
+import { AdminLeftMenuComponent } from '../components/admin/admin-left-menu/admin-left-menu.component';
 
 @Component({
   selector: 'app-leftsidebar',
   standalone: true,
-  imports: [CommonModule, PassengerLeftMenuComponent],
+  imports: [CommonModule, PassengerLeftMenuComponent, AdminLeftMenuComponent],
   templateUrl: './leftsidebar.component.html',
   styleUrl: './leftsidebar.component.css',
 })

--- a/frontend/komsiluk-taxiProject/src/app/features/profile/components/driver-blocked-dialog/driver-blocked-dialog.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/features/profile/components/driver-blocked-dialog/driver-blocked-dialog.component.css
@@ -1,0 +1,62 @@
+.ab-title{
+  font-size: var(--fs-h1);
+  margin-bottom: 18px;
+  color: var(--color-white);
+}
+
+.ab-sub{
+  font-size: var(--fs-md);
+  color: rgba(255,255,255,0.82);
+  margin-bottom: 18px;
+}
+
+.ab-label{
+  font-size: var(--fs-md);
+  color: rgba(255, 238, 2, 0.85);
+  margin-bottom: 8px;
+}
+
+.ab-reason{
+  border: 1px solid rgba(255, 238, 2, 0.35);
+  background: rgba(0,0,0,0.25);
+  padding: 10px 12px;
+  border-radius: 6px;
+  margin-bottom: 14px;
+}
+
+.ab-reason__text{
+  color: rgba(255,255,255,0.9);
+  font-style: italic;
+}
+
+.ab-reason__muted{
+  color: rgba(255,255,255,0.55);
+  font-style: italic;
+}
+
+.ab-meta{
+  margin-top: 8px;
+  font-size: 12px;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.ab-meta__k{
+  color: rgba(255,255,255,0.65);
+}
+
+.ab-meta__v{
+  color: var(--color-secondary);
+}
+
+.ab-foot{
+  font-size: 12px;
+  color: rgba(255,255,255,0.7);
+}
+
+.ab-actions{
+  margin-top: 18px;
+  display: flex;
+  justify-content: flex-end;
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/profile/components/driver-blocked-dialog/driver-blocked-dialog.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/features/profile/components/driver-blocked-dialog/driver-blocked-dialog.component.html
@@ -1,0 +1,36 @@
+<app-modal-shell [open]="open" (closed)="close.emit()">
+
+  <div class="ab-title text-regular">Account blocked</div>
+
+  <div class="ab-sub text-regular">
+    You can’t go active or receive new ride requests because your account has been blocked by an administrator.
+  </div>
+
+  <div class="ab-label text-regular">Reason from administrator:</div>
+
+  <div class="ab-reason text-regular">
+    @if (reason) {
+      <span class="ab-reason__text">{{ reason }}</span>
+    } @else {
+      <span class="ab-reason__muted">No reason provided.</span>
+    }
+
+    @if (adminEmail) {
+      <div class="ab-meta text-regular">
+        <span class="ab-meta__k">Admin:</span>
+        <span class="ab-meta__v">{{ adminEmail }}</span>
+      </div>
+    }
+  </div>
+
+  <div class="ab-foot text-regular">
+    If you believe this is a mistake, please contact support.
+  </div>
+
+  <div class="ab-actions">
+    <button type="button" class="btn btn--primary text-semibold btn-scale" (click)="close.emit()">
+      Confirm
+    </button>
+  </div>
+
+</app-modal-shell>

--- a/frontend/komsiluk-taxiProject/src/app/features/profile/components/driver-blocked-dialog/driver-blocked-dialog.component.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/profile/components/driver-blocked-dialog/driver-blocked-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DriverBlockedDialogComponent } from './driver-blocked-dialog.component';
+
+describe('DriverBlockedDialogComponent', () => {
+  let component: DriverBlockedDialogComponent;
+  let fixture: ComponentFixture<DriverBlockedDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DriverBlockedDialogComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DriverBlockedDialogComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/features/profile/components/driver-blocked-dialog/driver-blocked-dialog.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/profile/components/driver-blocked-dialog/driver-blocked-dialog.component.ts
@@ -1,0 +1,18 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ModalShellComponent } from '../../../../shared/components/modal-shell/modal-shell.component';
+
+@Component({
+  selector: 'app-driver-blocked-dialog',
+  standalone: true,
+  imports: [CommonModule, ModalShellComponent],
+  templateUrl: './driver-blocked-dialog.component.html',
+  styleUrl: './driver-blocked-dialog.component.css',
+})
+export class DriverBlockedDialogComponent {
+  @Input() open = false;
+  @Input() reason = '';
+  @Input() adminEmail = '';
+
+  @Output() close = new EventEmitter<void>();
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/profile/components/profile-sidebar/profile-sidebar.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/features/profile/components/profile-sidebar/profile-sidebar.component.css
@@ -235,3 +235,20 @@
 .profile-sidebar__divider::after {
   right: 2.5px;
 }
+
+.profile-sidebar__blocked{
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+
+  font-size: var(--fs-h1);
+  text-decoration: underline;
+  letter-spacing: 0.5px;
+
+  color: var(--color-text)
+}
+
+.profile-sidebar__blocked:hover{
+  opacity: 1;
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/profile/components/profile-sidebar/profile-sidebar.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/features/profile/components/profile-sidebar/profile-sidebar.component.html
@@ -89,17 +89,25 @@
     </nav>
 
     <div class="profile-sidebar__footer">
-        <!-- Active today -->
         @if (isDriver) {
-        <div class="profile-sidebar__active text-semibold">
-            Active today: {{ activeToday }}
-        </div>
+            @if (!isBlocked) {
+            <div class="profile-sidebar__active text-semibold">
+                Active today: {{ activeToday }}
+            </div>
+            } @else {
+            <button
+                type="button"
+                class="profile-sidebar__blocked text-semibold btn-scale"
+                (click)="blockedClick.emit()"
+            >
+                Blocked
+            </button>
+            }
         }
 
         <button type="button" class="profile-sidebar__logout btn-scale text-medium" (click)="logout()">
             <span class="profile-sidebar__logout-text">Log out</span>
             <span class="profile-sidebar__logout-icon" aria-hidden="true">
-            <!-- LOGOUT ARROW -->
             <svg viewBox="0 0 24 24">
                 <path d="M10 17l5-5-5-5" />
                 <path d="M15 12H3" />
@@ -108,5 +116,5 @@
             </svg>
             </span>
         </button>
-  </div>
+    </div>
 </div>

--- a/frontend/komsiluk-taxiProject/src/app/features/profile/components/profile-sidebar/profile-sidebar.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/profile/components/profile-sidebar/profile-sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { RouterLink, Router } from '@angular/router';
 import { AuthService } from '../../../../core/auth/services/auth.service';
 import { UserProfileResponseDTO } from '../../../../shared/models/profile.models';
@@ -14,6 +14,9 @@ export class ProfileSidebarComponent {
   @Input() activeToday: string = '-';
   @Input() profile: UserProfileResponseDTO | null = null;
   
+  @Input() isBlocked = false;
+  @Output() blockedClick = new EventEmitter<void>();
+
   authService: AuthService;
   router: Router;
 

--- a/frontend/komsiluk-taxiProject/src/app/features/profile/pages/driver-car-view/driver-car-view.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/features/profile/pages/driver-car-view/driver-car-view.component.html
@@ -1,10 +1,19 @@
 <div class="app-bg-textured profile-page">
   <app-profile-sidebar
-  [profile]="profile"
-  [isDriver]="true"
-  [activeToday]="activeToday">
+    [profile]="profile"
+    [isDriver]="true"
+    [activeToday]="activeToday"
+    [isBlocked]="isBlocked()"
+    (blockedClick)="openBlockedInfo()"
+  >
   </app-profile-sidebar>
-  <app-driver-car-details
-  [profile]="profile">
-  </app-driver-car-details>
+
+  <app-driver-car-details [profile]="profile"></app-driver-car-details>
+
+  <app-driver-blocked-dialog
+    [open]="blockedDialogOpen()"
+    [reason]="blockNote?.reason || ''"
+    [adminEmail]="blockNote?.adminEmail || ''"
+    (close)="blockedDialogOpen.set(false)"
+  />
 </div>

--- a/frontend/komsiluk-taxiProject/src/app/features/profile/pages/profile-view/profile-view.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/features/profile/pages/profile-view/profile-view.component.html
@@ -1,11 +1,22 @@
 <div class="app-bg-textured profile-page">
-    <app-profile-sidebar
-        [profile]="profile"
-        [isDriver]="isDriver"
-        [activeToday]="activeToday">
-    </app-profile-sidebar>
-    <app-profile-details
-        [profile]="profile"
-        [isDriver]="isDriver">
-    </app-profile-details>
+  <app-profile-sidebar
+    [profile]="profile"
+    [isDriver]="isDriver"
+    [activeToday]="activeToday"
+    [isBlocked]="isBlocked()"
+    (blockedClick)="openBlockedInfo()"
+  >
+  </app-profile-sidebar>
+
+  <app-profile-details
+    [profile]="profile"
+    [isDriver]="isDriver">
+  </app-profile-details>
+
+  <app-driver-blocked-dialog
+    [open]="blockedDialogOpen()"
+    [reason]="blockNote?.reason || ''"
+    [adminEmail]="blockNote?.adminEmail || ''"
+    (close)="blockedDialogOpen.set(false)"
+  />
 </div>

--- a/frontend/komsiluk-taxiProject/src/app/features/profile/services/profile.service.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/profile/services/profile.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { AuthService } from '../../../core/auth/services/auth.service';
 import { UserProfileResponseDTO, UserProfileUpdateDTO, DriverEditRequestCreateDTO, DriverEditRequestResponseDTO } from '../../../shared/models/profile.models';
+import { UserBlockedDTO } from '../../../shared/models/block-note.model';
 
 @Injectable({ providedIn: 'root' })
 export class ProfileService {
@@ -38,5 +39,9 @@ export class ProfileService {
     const driverId = this.auth.userId();
 
     return this.http.post<DriverEditRequestResponseDTO>(`${this.DRIVER_EDIT_API}/${driverId}`, dto);
+  }
+
+  isUserBlocked(userId: number): Observable<UserBlockedDTO> {
+    return this.http.get<UserBlockedDTO>(`${this.API}/${userId}/blocked`);
   }
 }

--- a/frontend/komsiluk-taxiProject/src/app/shared/components/modal-shell/services/account-blocked-modal.service.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/shared/components/modal-shell/services/account-blocked-modal.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AccountBlockedModalService } from './account-blocked-modal.service';
+
+describe('AccountBlockedModalService', () => {
+  let service: AccountBlockedModalService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AccountBlockedModalService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/shared/components/modal-shell/services/account-blocked-modal.service.ts
+++ b/frontend/komsiluk-taxiProject/src/app/shared/components/modal-shell/services/account-blocked-modal.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, signal, computed } from '@angular/core';
+
+export interface AccountBlockedModalData {
+  adminEmail?: string;
+  reason?: string;
+  createdAt?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AccountBlockedModalService {
+  private openSig = signal(false);
+  open = computed(() => this.openSig());
+
+  private dataSig = signal<AccountBlockedModalData | null>(null);
+  data = computed(() => this.dataSig());
+
+  openModal(data: AccountBlockedModalData) {
+    this.dataSig.set(data);
+    this.openSig.set(true);
+  }
+
+  close() {
+    this.openSig.set(false);
+    this.dataSig.set(null);
+  }
+}

--- a/frontend/komsiluk-taxiProject/src/app/shared/components/modal-shell/services/block-user-confirm-modal.service.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/shared/components/modal-shell/services/block-user-confirm-modal.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { BlockUserConfirmModalService } from './block-user-confirm-modal.service';
+
+describe('BlockUserConfirmModalService', () => {
+  let service: BlockUserConfirmModalService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BlockUserConfirmModalService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/shared/components/modal-shell/services/block-user-confirm-modal.service.ts
+++ b/frontend/komsiluk-taxiProject/src/app/shared/components/modal-shell/services/block-user-confirm-modal.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, signal, computed } from '@angular/core';
+
+export interface BlockUserConfirmModalData {
+  email: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class BlockUserConfirmModalService {
+  private openSig = signal(false);
+  open = computed(() => this.openSig());
+
+  private dataSig = signal<BlockUserConfirmModalData | null>(null);
+  data = computed(() => this.dataSig());
+
+  private onConfirm: ((reason: string) => void) | null = null;
+
+  openModal(data: BlockUserConfirmModalData, onConfirm?: (reason: string) => void) {
+    this.dataSig.set(data);
+    this.onConfirm = onConfirm ?? null;
+    this.openSig.set(true);
+  }
+
+  close() {
+    this.openSig.set(false);
+    this.dataSig.set(null);
+    this.onConfirm = null;
+  }
+
+  confirm(reason: string) {
+    this.onConfirm?.(reason);
+    this.close();
+  }
+}

--- a/frontend/komsiluk-taxiProject/src/app/shared/models/block-note.model.ts
+++ b/frontend/komsiluk-taxiProject/src/app/shared/models/block-note.model.ts
@@ -1,0 +1,17 @@
+export interface BlockNoteCreateDTO {
+  blockedUserEmail: string;
+  adminId: number;
+  reason: string;
+}
+
+export interface BlockNoteResponseDTO {
+  id: number;
+  blockedUserEmail: string;
+  adminEmail: string;
+  reason: string;
+  createdAt: string;
+}
+
+export interface UserBlockedDTO {
+    blocked: boolean;
+}


### PR DESCRIPTION
Implemented backend and frontend support for admin users to block other users. Added BlockNote entity, DTOs, service, repository, and controller on the backend. On the frontend, introduced admin panel components for blocking users, autocomplete email suggestions, block confirmation dialog, and blocked account dialog for passengers and drivers. Updated user service and controller to support blocked status and email autocomplete.

Closes #55 
Closes #56 