### PR TITLE
feat: Add admin UI for reviewing driver change requests

### DIFF
--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/controllers/ProfileChangeRequestController.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/controllers/ProfileChangeRequestController.java
@@ -46,8 +46,8 @@ public class ProfileChangeRequestController {
     }
 
     @PutMapping("/{requestId}/reject/{adminId}")
-    public ResponseEntity<ProfileChangeRequestResponseDTO> reject(@PathVariable Long requestId, @PathVariable Long adminId, @RequestBody String reason) {
-        var updated = service.reject(requestId, adminId, reason);
+    public ResponseEntity<ProfileChangeRequestResponseDTO> reject(@PathVariable Long requestId, @PathVariable Long adminId) {
+        var updated = service.reject(requestId, adminId);
         return ResponseEntity.ok(updated);
     }
 }

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/ProfileChangeRequestService.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/ProfileChangeRequestService.java
@@ -73,7 +73,7 @@ public class ProfileChangeRequestService implements IProfileChangeRequestService
     }
 
     @Override
-    public ProfileChangeRequestResponseDTO reject(Long requestId, Long adminId, String reason) {
+    public ProfileChangeRequestResponseDTO reject(Long requestId, Long adminId) {
         ProfileChangeRequest req = repo.findById(requestId);
         if (req == null) throw new NotFoundException();
 

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/interfaces/IProfileChangeRequestService.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/interfaces/IProfileChangeRequestService.java
@@ -13,5 +13,5 @@ public interface IProfileChangeRequestService {
     
     public ProfileChangeRequestResponseDTO approve(Long requestId, Long adminId);
     
-    public ProfileChangeRequestResponseDTO reject(Long requestId, Long adminId, String reason);
+    public ProfileChangeRequestResponseDTO reject(Long requestId, Long adminId);
 }

--- a/frontend/komsiluk-taxiProject/src/app/app.routes.ts
+++ b/frontend/komsiluk-taxiProject/src/app/app.routes.ts
@@ -16,6 +16,7 @@ import { DriverRideHistoryPageComponent } from './features/driver-history/pages/
 import { authGuard } from './core/auth/guards/auth.guard';
 import { roleGuard } from './core/auth/guards/role.guard';
 import { UserRole } from './core/auth/services/auth.service';
+import { AdminDriverChangeRequestsPageComponent } from './features/approve-edit/admin-driver-change-requests-page/admin-driver-change-requests-page.component';
 
 export const routes: Routes = [
 
@@ -62,6 +63,14 @@ export const routes: Routes = [
     path: 'usage-report',
     component: UsageReportsPageComponent,
     canActivate: [authGuard],
+  },
+
+  // ===== ADMIN =====
+  { 
+    path: 'driver-change-requests',
+    component: AdminDriverChangeRequestsPageComponent,
+    canActivate: [authGuard, roleGuard],
+    data: { roles: [UserRole.ADMIN] }
   },
 
   // ===== AUTH (PUBLIC, lazy) =====

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/rightsidebar.component/rightsidebar.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/rightsidebar.component/rightsidebar.component.html
@@ -42,7 +42,7 @@
         <a class="rightmenu__item rightmenu__item--active" routerLink="/profile">
           Profile
         </a>
-        <a class="rightmenu__item" routerLink="/support">
+        <a class="rightmenu__item" routerLink="/driver-change-requests">
           Support
         </a>
         <a class="rightmenu__item" routerLink="/about">

--- a/frontend/komsiluk-taxiProject/src/app/features/approve-edit/admin-driver-change-requests-page/admin-driver-change-requests-page.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/features/approve-edit/admin-driver-change-requests-page/admin-driver-change-requests-page.component.css
@@ -1,0 +1,141 @@
+.acr-page{
+  min-height: calc(100vh - 64px);
+  padding: 26px;
+  box-sizing: border-box;
+}
+
+.acr-wrap{
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.acr-head{
+  background: rgba(0,0,0,0.55);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-radius: 14px;
+  padding: 18px 18px 16px;
+  box-shadow: 0 12px 30px rgba(0,0,0,0.25);
+}
+
+.acr-title{
+  font-size: 40px;
+  color: var(--color-secondary);
+  letter-spacing: 0.5px;
+  margin-top: 4px;
+}
+
+.acr-sub{
+  margin-top: 6px;
+  color: rgba(255,255,255,0.82);
+  font-size: var(--fs-md);
+}
+
+.acr-line{
+  height: 2px;
+  width: 100%;
+  background: rgba(255, 238, 2, 0.9);
+  margin-top: 12px;
+}
+
+.acr-list{
+  margin-top: 18px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 50px;
+}
+
+.acr-card{
+  text-align: left;
+  border: 1px solid rgba(255, 238, 2, 0.25);
+  background: rgba(0,0,0,0.55);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-radius: 14px;
+  padding: 14px 14px 12px;
+  cursor: pointer;
+  color: rgba(255,255,255,0.95);
+  box-shadow: 0 10px 24px rgba(0,0,0,0.22);
+}
+
+.acr-card:hover{
+  border-color: rgba(255, 238, 2, 0.45);
+}
+
+.acr-card__top{
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.acr-card__email{
+  font-size: 16px;
+  color: rgba(255,255,255,0.95);
+}
+
+.acr-card__meta{
+  margin-top: 4px;
+  font-size: 12px;
+  color: rgba(255,255,255,0.70);
+}
+
+.acr-card__badge{
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(255, 238, 2, 0.14);
+  border: 1px solid rgba(255, 238, 2, 0.35);
+  color: rgba(255, 238, 2, 0.95);
+  letter-spacing: 0.5px;
+}
+
+.acr-card__chips{
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.acr-chip{
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.90);
+}
+
+.acr-card__hint{
+  margin-top: 12px;
+  font-size: 12px;
+  color: rgba(255,255,255,0.65);
+}
+
+.acr-empty{
+  grid-column: 1 / -1;
+  background: rgba(0,0,0,0.55);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-radius: 14px;
+  padding: 18px;
+  border: 1px solid rgba(255,255,255,0.10);
+  color: rgba(255,255,255,0.9);
+}
+
+.acr-empty__title{
+  font-size: 18px;
+  margin-bottom: 6px;
+  color: var(--color-secondary);
+}
+
+.acr-empty__sub{
+  font-size: 13px;
+  color: rgba(255,255,255,0.75);
+}
+
+@media (max-width: 980px){
+  .acr-list{
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/approve-edit/admin-driver-change-requests-page/admin-driver-change-requests-page.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/features/approve-edit/admin-driver-change-requests-page/admin-driver-change-requests-page.component.html
@@ -1,0 +1,59 @@
+<div class="app-bg-textured acr-page">
+  <div class="acr-wrap">
+
+    <header class="acr-head">
+      <div class="acr-title text-regular">Driver change requests</div>
+      <div class="acr-sub text-regular">Review and approve/reject pending profile & vehicle updates.</div>
+      <div class="acr-line"></div>
+    </header>
+
+    <section class="acr-list">
+
+      @if (requests().length === 0) {
+        <div class="acr-empty text-regular">
+          <div class="acr-empty__title text-semibold">No pending requests</div>
+          <div class="acr-empty__sub">All driver profiles are up to date.</div>
+        </div>
+      } @else {
+        @for (r of requests(); track r.id) {
+          <button type="button" class="acr-card btn-scale" (click)="openReview(r)">
+            <div class="acr-card__top">
+              <div class="acr-card__who">
+                <div class="acr-card__email text-semibold">
+                  {{ getCurrentFor(r).email }}
+                </div>
+                <div class="acr-card__meta text-regular">
+                  Request #{{ r.id }} • {{ r.requestedAt | date:'medium' }}
+                </div>
+              </div>
+
+              <div class="acr-card__badge text-semibold">PENDING</div>
+            </div>
+
+            <div class="acr-card__chips">
+              @for (c of requestChips(r); track c) {
+                <span class="acr-chip text-semibold">{{ c }}</span>
+              }
+            </div>
+
+            <div class="acr-card__hint text-regular">
+              Click to review details
+            </div>
+          </button>
+        }
+      }
+
+    </section>
+
+    <!-- Review dialog -->
+    <app-driver-change-request-review-dialog
+      [open]="dialogOpen()"
+      [driverEmail]="selectedCurrent()?.email || ''"
+      [requestedAt]="selectedReq()?.requestedAt || ''"
+      [rows]="diffRows()"
+      (close)="closeDialog()"
+      (approve)="approveSelected()"
+      (reject)="rejectSelected()"
+    />
+  </div>
+</div>

--- a/frontend/komsiluk-taxiProject/src/app/features/approve-edit/admin-driver-change-requests-page/admin-driver-change-requests-page.component.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/approve-edit/admin-driver-change-requests-page/admin-driver-change-requests-page.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminDriverChangeRequestsPageComponent } from './admin-driver-change-requests-page.component';
+
+describe('AdminDriverChangeRequestsPageComponent', () => {
+  let component: AdminDriverChangeRequestsPageComponent;
+  let fixture: ComponentFixture<AdminDriverChangeRequestsPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminDriverChangeRequestsPageComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AdminDriverChangeRequestsPageComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/features/approve-edit/admin-driver-change-requests-page/admin-driver-change-requests-page.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/approve-edit/admin-driver-change-requests-page/admin-driver-change-requests-page.component.ts
@@ -1,0 +1,206 @@
+import { Component, signal, computed, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ToastService } from '../../../shared/components/toast/toast.service';
+import { DriverChangeRequestReviewDialogComponent } from '../driver-change-request-review-dialog/driver-change-request-review-dialog.component';
+import { DriverEditRequestResponseDTO, UserProfileResponseDTO } from '../../../shared/models/profile.models';
+import { ProfileService } from '../../profile/services/profile.service';
+import { forkJoin, of } from 'rxjs';
+import { catchError, finalize, map, switchMap } from 'rxjs/operators';
+
+type DiffRow = {
+  key: string;
+  label: string;
+  current: string;
+  requested: string;
+};
+
+@Component({
+  selector: 'app-admin-driver-change-requests-page',
+  standalone: true,
+  imports: [CommonModule, DriverChangeRequestReviewDialogComponent],
+  templateUrl: './admin-driver-change-requests-page.component.html',
+  styleUrls: ['./admin-driver-change-requests-page.component.css'],
+})
+export class AdminDriverChangeRequestsPageComponent implements OnInit {
+  loading = signal(false);
+
+  requests = signal<DriverEditRequestResponseDTO[]>([]);
+  currentByDriverId = signal<Record<number, UserProfileResponseDTO>>({});
+
+  dialogOpen = signal(false);
+  selectedReq = signal<DriverEditRequestResponseDTO | null>(null);
+  selectedCurrent = signal<UserProfileResponseDTO | null>(null);
+
+  constructor(
+    private toast: ToastService,
+    private profileService: ProfileService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadPending();
+  }
+
+  private loadPending() {
+    this.loading.set(true);
+
+    this.profileService.getPendingDriverEditRequests().pipe(
+      switchMap((reqs) => {
+        this.requests.set(reqs ?? []);
+
+        const ids = Array.from(new Set((reqs ?? []).map(r => r.driverId).filter(Boolean)));
+
+        if (ids.length === 0) return of({ ids: [] as number[], profiles: [] as (UserProfileResponseDTO | null)[] });
+
+        return forkJoin(
+          ids.map(id =>
+            this.profileService.getProfileById(id).pipe(
+              catchError(() => of(null))
+            )
+          )
+        ).pipe(
+          map((profiles) => ({ ids, profiles }))
+        );
+      }),
+      finalize(() => this.loading.set(false))
+    ).subscribe({
+      next: ({ ids, profiles }) => {
+        const nextMap: Record<number, UserProfileResponseDTO> = { ...this.currentByDriverId() };
+
+        ids.forEach((id, i) => {
+          const p = profiles[i];
+          if (p) nextMap[id] = p;
+        });
+
+        this.currentByDriverId.set(nextMap);
+      },
+      error: (err) => {
+        console.error(err);
+        this.toast.show(err?.error?.message || 'Failed to load pending requests.');
+      }
+    });
+  }
+
+  // ===== helpers =====
+  private fmtBool(v: boolean) { return v ? 'Yes' : 'No'; }
+  private safeStr(v: any) { return (v === null || v === undefined || v === '') ? '—' : String(v); }
+
+  private buildDiff(current: UserProfileResponseDTO, req: DriverEditRequestResponseDTO): DiffRow[] {
+    const rows: DiffRow[] = [];
+
+    const add = (key: string, label: string, cur: any, next: any, formatter?: (x: any) => string) => {
+      if (next === null || next === undefined) return;
+      const curS = formatter ? formatter(cur) : this.safeStr(cur);
+      const nextS = formatter ? formatter(next) : this.safeStr(next);
+      if (curS !== nextS) rows.push({ key, label, current: curS, requested: nextS });
+    };
+
+    add('name', 'First name', current.firstName, req.newName);
+    add('surname', 'Last name', current.lastName, req.newSurname);
+    add('address', 'Address', current.address, req.newAddress);
+    add('city', 'City', current.city, req.newCity);
+    add('phone', 'Phone number', current.phoneNumber, req.newPhoneNumber);
+
+    add('model', 'Car model', current.vehicle?.model, req.newModel);
+    add('type', 'Vehicle type', current.vehicle?.type, req.newType);
+    add('plate', 'Licence plate', current.vehicle?.licencePlate, req.newLicencePlate);
+    add('seats', 'Seat count', current.vehicle?.seatCount, req.newSeatCount);
+
+    add('baby', 'Baby friendly', current.vehicle?.babyFriendly, req.newBabyFriendly, (x) => this.fmtBool(!!x));
+    add('pet', 'Pet friendly', current.vehicle?.petFriendly, req.newPetFriendly, (x) => this.fmtBool(!!x));
+
+    return rows;
+  }
+
+  getCurrentFor(req: DriverEditRequestResponseDTO): UserProfileResponseDTO {
+    const map = this.currentByDriverId();
+    return map[req.driverId] ?? {
+      email: `driver${req.driverId}@neighborhood.taxi`,
+      firstName: '—',
+      lastName: '—',
+      address: '—',
+      city: '—',
+      phoneNumber: '—',
+      profileImageUrl: '',
+      activeMinutesLast24h: 0,
+      vehicle: null,
+    };
+  }
+
+  requestChips(req: DriverEditRequestResponseDTO): string[] {
+    const c = this.getCurrentFor(req);
+    const diff = this.buildDiff(c, req);
+    const keys = new Set(diff.map(d => d.key));
+
+    const chips: string[] = [];
+    const anyIdentity = ['name','surname','phone'].some(k => keys.has(k));
+    const anyAddress  = ['address','city'].some(k => keys.has(k));
+    const anyCar      = ['model','type','plate','seats'].some(k => keys.has(k));
+    const anyPrefs    = ['baby','pet'].some(k => keys.has(k));
+
+    if (anyIdentity) chips.push('Identity');
+    if (anyAddress) chips.push('Address');
+    if (anyCar) chips.push('Car');
+    if (anyPrefs) chips.push('Preferences');
+    if (!chips.length) chips.push('No changes');
+
+    return chips;
+  }
+
+  openReview(req: DriverEditRequestResponseDTO) {
+    const cur = this.getCurrentFor(req);
+    this.selectedReq.set(req);
+    this.selectedCurrent.set(cur);
+    this.dialogOpen.set(true);
+  }
+
+  approveSelected() {
+    const req = this.selectedReq();
+    if (!req) return;
+
+    this.loading.set(true);
+    this.profileService.approveDriverEditRequest(req.id).pipe(
+      finalize(() => this.loading.set(false))
+    ).subscribe({
+      next: () => {
+        this.toast.show('Request approved.');
+        this.requests.set(this.requests().filter(r => r.id !== req.id));
+        this.dialogOpen.set(false);
+      },
+      error: (err) => {
+        console.error(err);
+        this.toast.show(err?.error?.message || 'Approve failed.');
+      }
+    });
+  }
+
+  rejectSelected() {
+    const req = this.selectedReq();
+    if (!req) return;
+
+    this.loading.set(true);
+    this.profileService.rejectDriverEditRequest(req.id).pipe(
+      finalize(() => this.loading.set(false))
+    ).subscribe({
+      next: () => {
+        this.toast.show('Request rejected.');
+        this.requests.set(this.requests().filter(r => r.id !== req.id));
+        this.dialogOpen.set(false);
+      },
+      error: (err) => {
+        console.error(err);
+        this.toast.show(err?.error?.message || 'Reject failed.');
+      }
+    });
+  }
+
+  closeDialog() {
+    this.dialogOpen.set(false);
+  }
+
+  diffRows = computed<DiffRow[]>(() => {
+    const req = this.selectedReq();
+    const cur = this.selectedCurrent();
+    if (!req || !cur) return [];
+    return this.buildDiff(cur, req);
+  });
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/approve-edit/driver-change-request-review-dialog/driver-change-request-review-dialog.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/features/approve-edit/driver-change-request-review-dialog/driver-change-request-review-dialog.component.css
@@ -1,0 +1,111 @@
+.acr-backdrop{
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.55);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  z-index: 2000;
+}
+
+.acr-modal{
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(920px, calc(100vw - 24px));
+  max-height: min(78vh, 760px);
+  overflow: auto;
+
+  background: rgba(0,0,0,0.78);
+  border: 1px solid rgba(255, 238, 2, 0.25);
+  border-radius: 14px;
+  padding: 14px;
+  box-shadow: 0 18px 40px rgba(0,0,0,0.35);
+  z-index: 2001;
+}
+
+.acr-modal__head{
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.acr-modal__title{
+  font-size: 28px;
+  color: var(--color-secondary);
+  letter-spacing: 0.4px;
+}
+
+.acr-x{
+  border: none;
+  background: rgba(255,255,255,0.06);
+  color: rgba(255,255,255,0.85);
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.acr-modal__meta{
+  margin-top: 10px;
+  display: grid;
+  gap: 6px;
+  color: rgba(255,255,255,0.82);
+  font-size: 13px;
+}
+
+.acr-modal__meta .k{
+  color: rgba(255,255,255,0.65);
+}
+
+.acr-modal__meta .v{
+  color: rgba(255,255,255,0.92);
+}
+
+.acr-table{
+  margin-top: 14px;
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(255,255,255,0.06);
+}
+
+.acr-row{
+  display: grid;
+  grid-template-columns: 220px 1fr 1fr;
+  gap: 10px;
+  padding: 10px 12px;
+  border-top: 1px solid rgba(255,255,255,0.10);
+  color: rgba(255,255,255,0.88);
+}
+
+.acr-row--head{
+  border-top: none;
+  background: rgba(255, 238, 2, 0.10);
+  color: rgba(255, 238, 2, 0.95);
+}
+
+.acr-field{
+  color: rgba(255,255,255,0.92);
+}
+
+.acr-val{
+  color: rgba(255,255,255,0.82);
+}
+
+.acr-val--new{
+  color: rgba(255, 238, 2, 0.95);
+}
+
+.acr-none{
+  padding: 12px;
+  color: rgba(255,255,255,0.75);
+}
+
+.acr-actions{
+  margin-top: 14px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/approve-edit/driver-change-request-review-dialog/driver-change-request-review-dialog.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/features/approve-edit/driver-change-request-review-dialog/driver-change-request-review-dialog.component.html
@@ -1,0 +1,45 @@
+@if (open) {
+  <div class="acr-backdrop" (click)="close.emit()"></div>
+
+  <div class="acr-modal" role="dialog" aria-modal="true">
+    <div class="acr-modal__head">
+      <div class="acr-modal__title text-regular">Review change request</div>
+      <button class="acr-x btn-scale" type="button" (click)="close.emit()">✕</button>
+    </div>
+
+    <div class="acr-modal__meta text-regular">
+      <div><span class="k">Driver: </span> <span class="v">{{ driverEmail }}</span></div>
+      <div><span class="k">Requested at: </span> <span class="v">{{ requestedAt | date:'medium' }}</span></div>
+    </div>
+
+    <div class="acr-table">
+      <div class="acr-row acr-row--head text-semibold">
+        <div>Field</div>
+        <div>Current</div>
+        <div>Requested</div>
+      </div>
+
+      @if (rows.length === 0) {
+        <div class="acr-none text-regular">No actual changes found in this request.</div>
+      } @else {
+        @for (r of rows; track r.key) {
+          <div class="acr-row text-regular">
+            <div class="acr-field text-semibold">{{ r.label }}</div>
+            <div class="acr-val">{{ r.current }}</div>
+            <div class="acr-val acr-val--new">{{ r.requested }}</div>
+          </div>
+        }
+      }
+    </div>
+
+    <div class="acr-actions">
+      <button type="button" class="btn btn--danger text-semibold btn-scale" (click)="reject.emit()">
+        Reject
+      </button>
+
+      <button type="button" class="btn btn--primary text-semibold btn-scale" (click)="approve.emit()">
+        Approve
+      </button>
+    </div>
+  </div>
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/approve-edit/driver-change-request-review-dialog/driver-change-request-review-dialog.component.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/approve-edit/driver-change-request-review-dialog/driver-change-request-review-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DriverChangeRequestReviewDialogComponent } from './driver-change-request-review-dialog.component';
+
+describe('DriverChangeRequestReviewDialogComponent', () => {
+  let component: DriverChangeRequestReviewDialogComponent;
+  let fixture: ComponentFixture<DriverChangeRequestReviewDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DriverChangeRequestReviewDialogComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DriverChangeRequestReviewDialogComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/features/approve-edit/driver-change-request-review-dialog/driver-change-request-review-dialog.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/approve-edit/driver-change-request-review-dialog/driver-change-request-review-dialog.component.ts
@@ -1,0 +1,30 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+type DiffRow = {
+  key: string;
+  label: string;
+  current: string;
+  requested: string;
+};
+
+@Component({
+  selector: 'app-driver-change-request-review-dialog',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './driver-change-request-review-dialog.component.html',
+  styleUrls: ['./driver-change-request-review-dialog.component.css']
+})
+export class DriverChangeRequestReviewDialogComponent {
+
+  constructor() { }
+
+  @Input() open = false;
+  @Input() driverEmail = '';
+  @Input() requestedAt = '';
+  @Input() rows: DiffRow[] = [];
+
+  @Output() close = new EventEmitter<void>();
+  @Output() approve = new EventEmitter<void>();
+  @Output() reject = new EventEmitter<void>();
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/profile/services/profile.service.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/profile/services/profile.service.ts
@@ -44,4 +44,17 @@ export class ProfileService {
   isUserBlocked(userId: number): Observable<UserBlockedDTO> {
     return this.http.get<UserBlockedDTO>(`${this.API}/${userId}/blocked`);
   }
+
+  getPendingDriverEditRequests(): Observable<DriverEditRequestResponseDTO[]> {
+    return this.http.get<DriverEditRequestResponseDTO[]>(`${this.DRIVER_EDIT_API}/pending`);
+  }
+  approveDriverEditRequest(requestId: number): Observable<DriverEditRequestResponseDTO> {
+    const adminId = Number(this.auth.userId());
+    return this.http.put<DriverEditRequestResponseDTO>(`${this.DRIVER_EDIT_API}/${requestId}/approve/${adminId}`, null);
+  }
+
+  rejectDriverEditRequest(requestId: number): Observable<DriverEditRequestResponseDTO> {
+    const adminId = Number(this.auth.userId());
+    return this.http.put<DriverEditRequestResponseDTO>(`${this.DRIVER_EDIT_API}/${requestId}/reject/${adminId}`, null);
+  }
 }

--- a/frontend/komsiluk-taxiProject/src/app/shared/models/profile.models.ts
+++ b/frontend/komsiluk-taxiProject/src/app/shared/models/profile.models.ts
@@ -47,11 +47,23 @@ export interface DriverEditRequestCreateDTO {
   newPetFriendly: boolean;
 }
 
-export interface DriverEditRequestResponseDTO {
+export type DriverEditRequestResponseDTO = {
   id: number;
   requestedAt: string;
-  status: string;
-  driverId: number;
+  status: 'PENDING' | 'APPROVED' | 'REJECTED';
 
-  // no need for other fields right now
-}
+  newName?: string | null;
+  newSurname?: string | null;
+  newAddress?: string | null;
+  newCity?: string | null;
+  newPhoneNumber?: string | null;
+
+  newModel?: string | null;
+  newType?: VehicleType | null;
+  newLicencePlate?: string | null;
+  newSeatCount?: number | null;
+  newBabyFriendly?: boolean | null;
+  newPetFriendly?: boolean | null;
+
+  driverId: number;
+};


### PR DESCRIPTION
Introduces a new admin page and dialog for reviewing, approving, or rejecting pending driver profile and vehicle change requests. Updates backend endpoints to remove the 'reason' parameter from reject methods. Adds related service methods, routes, and UI components, and extends the DriverEditRequestResponseDTO model to include all relevant fields for diffing.



Closes #63 
Closes #64 