### PR TITLE
Ride planning state handling across auth flows

### DIFF
--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/guest/guest-book-ride-panel/guest-book-ride-panel.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/guest/guest-book-ride-panel/guest-book-ride-panel.component.html
@@ -5,26 +5,21 @@
     <div class="br-label">Pickup location</div>
 
     <div class="br-input-wrap">
-      <input
-        class="br-input"
-        type="text"
-        placeholder="Start"
-        [value]="pickupText()"
-        (input)="pickupText.set($any($event.target).value)"
-      />
+      <input class="br-input" type="text" placeholder="Start" [value]="ridePlanner.pickupText()"
+        (input)="ridePlanner.setPickupText($any($event.target).value)" />
       <button class="br-search-btn" type="button" (click)="searchPickup()">
         <span class="material-symbols-outlined btn-search-icon">search</span>
       </button>
     </div>
 
     @if (pickupSuggestions().length) {
-      <div class="br-suggest">
-        @for (s of pickupSuggestions(); track s.lat + ',' + s.lon) {
-          <button class="br-suggest__item" (click)="selectPickup(s)">
-            {{ s.label }}
-          </button>
-        }
-      </div>
+    <div class="br-suggest">
+      @for (s of pickupSuggestions(); track s.lat + ',' + s.lon) {
+      <button class="br-suggest__item" (click)="selectPickup(s)">
+        {{ s.label }}
+      </button>
+      }
+    </div>
     }
   </div>
 
@@ -33,52 +28,42 @@
     <div class="br-label">Destination</div>
 
     <div class="br-input-wrap">
-      <input
-        class="br-input"
-        type="text"
-        placeholder="Finish"
-        [value]="destinationText()"
-        (input)="destinationText.set($any($event.target).value)"
-      />
+      <input class="br-input" type="text" placeholder="Finish" [value]="ridePlanner.destinationText()"
+        (input)="ridePlanner.setDestinationText($any($event.target).value)" />
       <button class="br-search-btn" type="button" (click)="searchDestination()">
         <span class="material-symbols-outlined btn-search-icon">search</span>
       </button>
     </div>
 
     @if (destinationSuggestions().length) {
-      <div class="br-suggest">
-        @for (s of destinationSuggestions(); track s.lat + ',' + s.lon) {
-          <button class="br-suggest__item" (click)="selectDestination(s)">
-            {{ s.label }}
-          </button>
-        }
-      </div>
+    <div class="br-suggest">
+      @for (s of destinationSuggestions(); track s.lat + ',' + s.lon) {
+      <button class="br-suggest__item" (click)="selectDestination(s)">
+        {{ s.label }}
+      </button>
+      }
+    </div>
     }
   </div>
 
   <!-- Stats -->
   @if (hasRoute()) {
-    <div class="br-stats">
-      <div class="br-stat">
-        <span class="material-symbols-outlined">route</span>
-        <span>Kilometers: {{ ridePlanner.km().toFixed(1) }}</span>
-      </div>
-
-      <div class="br-stat">
-        <span class="material-symbols-outlined">schedule</span>
-        <span>Drive time: {{ ridePlanner.minutes() }} min</span>
-      </div>
+  <div class="br-stats">
+    <div class="br-stat">
+      <span class="material-symbols-outlined">route</span>
+      <span>Kilometers: {{ ridePlanner.km().toFixed(1) }}</span>
     </div>
+
+    <div class="br-stat">
+      <span class="material-symbols-outlined">schedule</span>
+      <span>Drive time: {{ ridePlanner.minutes() }} min</span>
+    </div>
+  </div>
   }
 
-  <!-- Action -->
-  <button
-    class="btn btn--primary btn-scale"
-    type="button"
-    [disabled]="!hasRoute()"
-    (click)="requestLogin()"
-  >
+  <button class="btn btn--primary btn-scale" type="button" (click)="onBookClick()">
     Book a ride
   </button>
+
 
 </div>

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/guest/guest-book-ride-panel/guest-book-ride-panel.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/guest/guest-book-ride-panel/guest-book-ride-panel.component.ts
@@ -17,59 +17,55 @@ import { GeoPoint } from '../../../../../shared/components/map/services/routing.
 })
 export class GuestBookRidePanelComponent {
 
-  // input text
-  pickupText = signal('');
-  destinationText = signal('');
 
-  // suggestions
+
   pickupSuggestions = signal<AddressSuggestion[]>([]);
   destinationSuggestions = signal<AddressSuggestion[]>([]);
 
   constructor(
     private geocoding: GeocodingService,
     public ridePlanner: RidePlannerService,
-    private loginRequiredModal: LoginRequiredModalService
+    private loginRequiredModal: LoginRequiredModalService,
+    private toast: ToastService
   ) { }
 
-  /* ---------------- SEARCH ---------------- */
+
 
   searchPickup() {
-    const q = this.pickupText();
+    const q = this.ridePlanner.pickupText();
     this.geocoding.search(q).subscribe(list => {
       this.pickupSuggestions.set(list);
     });
   }
 
   searchDestination() {
-    const q = this.destinationText();
+    const q = this.ridePlanner.destinationText();
     this.geocoding.search(q).subscribe(list => {
       this.destinationSuggestions.set(list);
     });
   }
 
-  /* ---------------- SELECT ---------------- */
+
 
   selectPickup(s: AddressSuggestion) {
-    this.pickupText.set(s.label);
+    this.ridePlanner.setPickupText(s.label);
     this.pickupSuggestions.set([]);
 
     this.ridePlanner.setPickup(this.toPoint(s));
   }
 
   selectDestination(s: AddressSuggestion) {
-    this.destinationText.set(s.label);
+    this.ridePlanner.setDestinationText(s.label);
     this.destinationSuggestions.set([]);
 
     this.ridePlanner.setDestination(this.toPoint(s));
   }
 
-  /* ---------------- STATE ---------------- */
 
-  hasRoute = computed(() => {
-    return this.ridePlanner.route() !== null;
-  });
 
-  /* ---------------- ACTION ---------------- */
+  hasRoute = computed(() => this.ridePlanner.route() !== null);
+
+
 
   requestLogin() {
     this.loginRequiredModal.open({
@@ -80,7 +76,17 @@ export class GuestBookRidePanelComponent {
     });
   }
 
-  /* ---------------- UTIL ---------------- */
+  onBookClick() {
+    if (!this.ridePlanner.pickup() || !this.ridePlanner.destination()) {
+      this.toast.show('Please select both pickup and destination locations.');
+      return;
+    }
+
+    this.requestLogin();
+  }
+
+
+
 
   private toPoint(s: AddressSuggestion): GeoPoint {
     return {

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/components/passenger/book_ride/passenger-book-ride-panel/passenger-book-ride-panel.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/components/passenger/book_ride/passenger-book-ride-panel/passenger-book-ride-panel.component.ts
@@ -1,5 +1,5 @@
 import { Component, signal, OnDestroy, OnInit, ChangeDetectorRef, ElementRef, ViewChild } from '@angular/core';
-import { Subscription, switchMap, catchError, of, tap, map, finalize, forkJoin} from 'rxjs';
+import { Subscription, switchMap, catchError, of, tap, map, finalize, forkJoin } from 'rxjs';
 import { CommonModule } from '@angular/common';
 import { FormArray, FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { VehicleType } from '../../../../../../shared/models/profile.models';
@@ -79,7 +79,44 @@ export class PassengerBookRidePanelComponent implements OnInit, OnDestroy {
     });
   }
 
+  private prefillFromPlanner(): void {
+    const pickup = this.ridePlanner.pickup();
+    const dest = this.ridePlanner.destination();
+
+    if (pickup) {
+      this.form.patchValue({ pickup: pickup.label }, { emitEvent: false });
+      this.pickupPoint = pickup
+        ? {
+          lat: pickup.lat,
+          lon: pickup.lon,
+          label: pickup.label ?? '',
+        }
+        : null;
+
+    }
+
+    if (dest) {
+      this.form.patchValue({ destination: dest.label }, { emitEvent: false });
+      this.destinationPoint = dest
+        ? {
+          lat: dest.lat,
+          lon: dest.lon,
+          label: dest.label ?? '',
+        }
+        : null;
+
+    }
+
+    this.cdr.detectChanges();
+  }
+
+  
+
+
+
   ngOnInit(): void {
+    this.prefillFromPlanner();
+
     this.subs.push(
       this.form.get('vehicleType')!.valueChanges.subscribe(v => {
         if (v) this.ridePlanner.setVehicleType(v as any);
@@ -271,7 +308,7 @@ export class PassengerBookRidePanelComponent implements OnInit, OnDestroy {
         : null;
 
     const stops = this.stationPoints
-      .filter((p): p is {lat:number; lon:number; label:string} => !!p)
+      .filter((p): p is { lat: number; lon: number; label: string } => !!p)
       .map(p => p.label);
 
     const passengerEmails = (this.users.value as any[])
@@ -299,6 +336,8 @@ export class PassengerBookRidePanelComponent implements OnInit, OnDestroy {
       this.toast.show('Not logged in.');
       return;
     }
+
+
 
     this.profileService.isUserBlocked(+userId).pipe(
       switchMap(res => {
@@ -353,7 +392,7 @@ export class PassengerBookRidePanelComponent implements OnInit, OnDestroy {
         if (fresh.length > 0) return fresh;
 
         if ((notifs ?? []).length > 0) {
-          const sorted = [...notifs].sort((a,b) => +new Date(b.createdAt) - +new Date(a.createdAt));
+          const sorted = [...notifs].sort((a, b) => +new Date(b.createdAt) - +new Date(a.createdAt));
           return sorted.slice(0, 1);
         }
 
@@ -371,7 +410,7 @@ export class PassengerBookRidePanelComponent implements OnInit, OnDestroy {
         }
 
         for (const n of notifsToShow) {
-          this.notification.markRead(n.id, true).subscribe({ error: () => {} });
+          this.notification.markRead(n.id, true).subscribe({ error: () => { } });
         }
       }),
 

--- a/frontend/komsiluk-taxiProject/src/app/shared/components/map/services/ride-planner.service.ts
+++ b/frontend/komsiluk-taxiProject/src/app/shared/components/map/services/ride-planner.service.ts
@@ -5,6 +5,22 @@ import { VehicleType } from '../../../models/profile.models';
 
 @Injectable({ providedIn: 'root' })
 export class RidePlannerService {
+
+
+  private pickupTextSig = signal('');
+  private destinationTextSig = signal('');
+
+  pickupText = computed(() => this.pickupTextSig());
+  destinationText = computed(() => this.destinationTextSig());
+
+  setPickupText(v: string) {
+    this.pickupTextSig.set(v);
+  }
+
+  setDestinationText(v: string) {
+    this.destinationTextSig.set(v);
+  }
+
   private pickupSig = signal<GeoPoint | null>(null);
   private destSig = signal<GeoPoint | null>(null);
   private stopsSig = signal<GeoPoint[]>([]);
@@ -35,7 +51,7 @@ export class RidePlannerService {
   constructor(
     private routing: RoutingService,
     private mapFacade: MapFacadeService
-  ) {}
+  ) { }
 
   setPickup(p: GeoPoint | null) {
     this.pickupSig.set(p);
@@ -79,4 +95,17 @@ export class RidePlannerService {
       }
     });
   }
+
+  reset(): void {
+    this.pickupTextSig.set('');
+    this.destinationTextSig.set('');
+
+    this.pickupSig.set(null);
+    this.destSig.set(null);
+    this.stopsSig.set([]);
+    this.routeSig.set(null);
+
+    this.mapFacade.setState(null);
+  }
+
 }

--- a/frontend/komsiluk-taxiProject/src/app/shared/components/message-page/message-page.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/shared/components/message-page/message-page.component.ts
@@ -6,6 +6,7 @@ import { ToastService } from '../toast/toast.service';
 import { AuthService } from '../../../core/auth/services/auth.service';
 
 import { MESSAGE_REGISTRY, MessageAction, MessageId } from './message-registry';
+import { RidePlannerService } from '../map/services/ride-planner.service';
 
 @Component({
   selector: 'app-message-page',
@@ -20,6 +21,7 @@ export class MessagePageComponent {
 
   constructor(
     private route: ActivatedRoute,
+    private ridePlanner: RidePlannerService,
     private router: Router,
     private auth: AuthService,
     private toast: ToastService
@@ -46,5 +48,6 @@ export class MessagePageComponent {
     this.auth.logout();
     if (a.toast) this.toast.show(a.toast);
     this.router.navigateByUrl(a.urlAfter);
+    this.ridePlanner.reset();
   }
 }


### PR DESCRIPTION
## 🧭 Ride planning state handling across auth flows

### ✅ Summary
This PR improves ride planning UX by correctly preserving and resetting route state depending on user authentication flow and role.

### 🔧 Key changes
- Preserved planned route and input data when a **guest logs in as a passenger**, allowing the user to continue where they left off
- Added **prefill logic** for the passenger booking form based on `RidePlannerService`
- Introduced **explicit state reset** of `RidePlannerService` on:
  - user logout
  - login as **driver**, since ride planning is not applicable to that role
- Added a **toast notification** when booking is attempted without selecting both pickup and destination locations

### 🧠 Rationale
`RidePlannerService` is implemented as a singleton to preserve ride planning state across navigation.
The state is explicitly reset when it becomes invalid (logout or driver login) to prevent data leakage
between sessions and to ensure correct UX per user role.

Closses #84 