### PR TITLE
Add admin driver registration and activation flow

### DIFF
--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/beans/User.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/beans/User.java
@@ -24,7 +24,6 @@ public class User implements UserDetails {
 	@Column(unique = true, nullable = false)
 	private String email;
 	
-	@Column(nullable = false)
 	private String passwordHash;
 	
 	@Column(nullable = false)

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/controllers/DriverController.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/controllers/DriverController.java
@@ -16,9 +16,14 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.validation.Valid;
+
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 
 import rs.ac.uns.ftn.iss.Komsiluk.dtos.driver.DriverCreateDTO;
 import rs.ac.uns.ftn.iss.Komsiluk.dtos.driver.DriverResponseDTO;
@@ -28,41 +33,44 @@ import rs.ac.uns.ftn.iss.Komsiluk.dtos.ride.RideResponseDTO;
 import rs.ac.uns.ftn.iss.Komsiluk.services.interfaces.IRideService;
 
 @RestController
-@PreAuthorize("hasRole('DRIVER')")
 @RequestMapping(value = "/api/drivers")
 public class DriverController {
 
 	@Autowired
     private IDriverService driverService;
-
     @Autowired
     private IRideService rideService;
 
 
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Collection<DriverResponseDTO>> getAllDrivers() {
         Collection<DriverResponseDTO> drivers = driverService.getAllDrivers();
         return new ResponseEntity<>(drivers, HttpStatus.OK);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<DriverResponseDTO> getDriver(@PathVariable("id") Long id) {
         DriverResponseDTO driver = driverService.getDriver(id);
         return new ResponseEntity<>(driver, HttpStatus.OK);
     }
-
-    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<DriverResponseDTO> registerDriver(@RequestBody DriverCreateDTO dto) {
-        DriverResponseDTO created = driverService.registerDriver(dto);
+    
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<DriverResponseDTO> registerDriver(@Valid @RequestPart("data") DriverCreateDTO dto, @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
+        DriverResponseDTO created = driverService.registerDriver(dto, profileImage);
         return new ResponseEntity<>(created, HttpStatus.CREATED);
     }
 
+    @PreAuthorize("hasRole('DRIVER')")
     @PutMapping("/{id}/status")
     public ResponseEntity<DriverResponseDTO> updateStatus(@PathVariable Long id, @RequestBody DriverStatusUpdateDTO dto) {
         DriverResponseDTO updated = driverService.updateDriverStatus(id, dto.getStatus());
         return new ResponseEntity<>(updated, HttpStatus.OK);
     }
 
+    @PreAuthorize("hasRole('DRIVER')")
     @GetMapping(value = "/{id}/rides/history", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Collection<RideResponseDTO>> getDriverRideHistory(
             @PathVariable("id") Long driverId,

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/DriverService.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/DriverService.java
@@ -4,22 +4,27 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import rs.ac.uns.ftn.iss.Komsiluk.beans.User;
+import rs.ac.uns.ftn.iss.Komsiluk.beans.Vehicle;
 import rs.ac.uns.ftn.iss.Komsiluk.beans.enums.DriverStatus;
 import rs.ac.uns.ftn.iss.Komsiluk.beans.enums.UserRole;
 import rs.ac.uns.ftn.iss.Komsiluk.dtos.driver.DriverCreateDTO;
 import rs.ac.uns.ftn.iss.Komsiluk.dtos.driver.DriverResponseDTO;
+import rs.ac.uns.ftn.iss.Komsiluk.dtos.userToken.UserTokenResponseDTO;
 import rs.ac.uns.ftn.iss.Komsiluk.mappers.DriverDTOMapper;
+import rs.ac.uns.ftn.iss.Komsiluk.mappers.VehicleDTOMapper;
 import rs.ac.uns.ftn.iss.Komsiluk.repositories.UserRepository;
 import rs.ac.uns.ftn.iss.Komsiluk.services.exceptions.AlreadyExistsException;
 import rs.ac.uns.ftn.iss.Komsiluk.services.exceptions.NotFoundException;
 import rs.ac.uns.ftn.iss.Komsiluk.services.interfaces.IDriverActivityService;
 import rs.ac.uns.ftn.iss.Komsiluk.services.interfaces.IDriverService;
+import rs.ac.uns.ftn.iss.Komsiluk.services.interfaces.IUserService;
 import rs.ac.uns.ftn.iss.Komsiluk.services.interfaces.IUserTokenService;
-import rs.ac.uns.ftn.iss.Komsiluk.services.interfaces.IVehicleService;
-import rs.ac.uns.ftn.iss.Komsiluk.services.interfaces.IDriverLocationService;
 
 @Service
 public class DriverService implements IDriverService {
@@ -31,12 +36,15 @@ public class DriverService implements IDriverService {
 	@Autowired
     private IUserTokenService userTokenService;
 	@Autowired
-	private IVehicleService vehicleService;
-	@Autowired
 	private IDriverActivityService driverActivityService;
     @Autowired
-    private IDriverLocationService driverLocationService;
-
+    private MailService mailService;
+    @Autowired
+    private VehicleDTOMapper vehicleMapper;
+    @Autowired
+    private IUserService userService;
+    @Value("${app.user.default-profile-image}")
+    private String defaultProfileImageUrl;
 
     @Override
     public Collection<DriverResponseDTO> getAllDrivers() {
@@ -53,7 +61,9 @@ public class DriverService implements IDriverService {
     }
 
     @Override
-    public DriverResponseDTO registerDriver(DriverCreateDTO dto) {
+    @Transactional
+    public DriverResponseDTO registerDriver(DriverCreateDTO dto, MultipartFile profileImage) {
+
         if (userRepository.existsByEmailIgnoreCase(dto.getEmail())) {
             throw new AlreadyExistsException();
         }
@@ -63,18 +73,27 @@ public class DriverService implements IDriverService {
         driver.setRole(UserRole.DRIVER);
         driver.setActive(false);
         driver.setDriverStatus(DriverStatus.INACTIVE);
-        
+
+        driver.setProfileImageUrl(defaultProfileImageUrl);
+
         if (dto.getVehicle() != null) {
-			driver.getVehicle().setId(vehicleService.create(dto.getVehicle()).getId());
-		}
+            Vehicle vehicle = vehicleMapper.fromCreateDTO(dto.getVehicle());
+            driver.setVehicle(vehicle);
+        }
 
         userRepository.save(driver);
 
-        userTokenService.createActivationToken(driver.getId());
+        if (profileImage != null && !profileImage.isEmpty()) {
+            userService.updateProfileImage(driver.getId(), profileImage);
+        }
+
+        UserTokenResponseDTO token = userTokenService.createActivationToken(driver.getId());
+
+        mailService.sendDriverActivationMail(driver.getEmail(), token.getToken());
 
         return driverMapper.toResponseDTO(driver);
     }
-    
+
     @Override
     public DriverResponseDTO updateDriverStatus(Long driverId, DriverStatus newStatus) {
         User driver = userRepository.findById(driverId).orElseThrow(NotFoundException::new);

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/MailService.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/MailService.java
@@ -30,6 +30,24 @@ public class MailService {
 
         mailSender.send(message);
     }
+    
+    public void sendDriverActivationMail(String to, String token) {
+
+        String activationLink =
+                "http://localhost:4200/driver-activation?token=" + token;
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("Activate your Komsiluk account");
+        message.setText(
+                "Welcome!\n\n" +
+                        "Click the link below to activate your account:\n\n" +
+                        activationLink + "\n\n" +
+                        "This link expires in 24 hours."
+        );
+
+        mailSender.send(message);
+    }
 
     public void sendPasswordResetMail(String to, String token) {
 

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/interfaces/IDriverService.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/interfaces/IDriverService.java
@@ -2,6 +2,8 @@ package rs.ac.uns.ftn.iss.Komsiluk.services.interfaces;
 
 import java.util.Collection;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import rs.ac.uns.ftn.iss.Komsiluk.beans.enums.DriverStatus;
 import rs.ac.uns.ftn.iss.Komsiluk.dtos.driver.DriverCreateDTO;
 import rs.ac.uns.ftn.iss.Komsiluk.dtos.driver.DriverResponseDTO;
@@ -12,7 +14,7 @@ public interface IDriverService {
 
     public DriverResponseDTO getDriver(Long id);
 
-    public DriverResponseDTO registerDriver(DriverCreateDTO dto);
+    public DriverResponseDTO registerDriver(DriverCreateDTO dto, MultipartFile profileImage);
 
     public DriverResponseDTO updateDriverStatus(Long driverId, DriverStatus newStatus);
 }

--- a/frontend/komsiluk-taxiProject/src/app/app.routes.ts
+++ b/frontend/komsiluk-taxiProject/src/app/app.routes.ts
@@ -18,6 +18,8 @@ import { roleGuard } from './core/auth/guards/role.guard';
 import { UserRole } from './core/auth/services/auth.service';
 import { AdminDriverChangeRequestsPageComponent } from './features/approve-edit/admin-driver-change-requests-page/admin-driver-change-requests-page.component';
 
+import { AdminDriverRegistrationPageComponent } from './features/add-driver/admin-driver-registration-page/admin-driver-registration-page.component';
+
 export const routes: Routes = [
 
   // ===== PUBLIC =====
@@ -69,6 +71,12 @@ export const routes: Routes = [
   { 
     path: 'driver-change-requests',
     component: AdminDriverChangeRequestsPageComponent,
+    canActivate: [authGuard, roleGuard],
+    data: { roles: [UserRole.ADMIN] }
+  },
+  {
+    path: 'admin/add-driver',
+    component: AdminDriverRegistrationPageComponent,
     canActivate: [authGuard, roleGuard],
     data: { roles: [UserRole.ADMIN] }
   },

--- a/frontend/komsiluk-taxiProject/src/app/core/auth/services/auth.service.ts
+++ b/frontend/komsiluk-taxiProject/src/app/core/auth/services/auth.service.ts
@@ -39,6 +39,10 @@ export interface ResetPasswordRequest {
   confirmPassword: string;
 }
 
+export interface DriverActivationRequest {
+  token: string;
+  password: string;
+}
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
@@ -167,4 +171,8 @@ export class AuthService {
     return this.http.post<void>(`${this.API}/tokens/reset-password`, payload);
   }
 
+  activateDriver(token: string, password: string) {
+    const payload: DriverActivationRequest = { token, password };
+    return this.http.post<void>(`${this.API}/tokens/activation`, payload);
+  }
 }

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/admin-driver-registration-page/admin-driver-registration-page.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/admin-driver-registration-page/admin-driver-registration-page.component.css
@@ -1,0 +1,11 @@
+:host{
+  display:block;
+}
+
+:host ::ng-deep app-auth-card.auth-card--vehicle .card-panel{
+  width: min(520px, 92vw);
+}
+
+:host ::ng-deep app-auth-card.auth-card--success .card-panel{
+  width: min(520px, 92vw);
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/admin-driver-registration-page/admin-driver-registration-page.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/admin-driver-registration-page/admin-driver-registration-page.component.html
@@ -1,0 +1,32 @@
+<app-auth-card
+  title="Registration"
+  [ngClass]="{
+    'auth-card--wide': step() === 1,
+    'auth-card--vehicle': step() === 2,
+    'auth-card--success': step() === 3
+  }"
+>
+
+@if (step() === 1) {
+    <app-admin-driver-registration-driver-panel
+    [form]="driverForm"
+    (next)="goNextFromDriver()"
+    />
+}
+
+@if (step() === 2) {
+    <app-admin-driver-registration-vehicle-panel
+    [form]="vehicleForm"
+    [creating]="creating()"
+    (back)="goBackToDriver()"
+    (create)="createDriver()"
+    />
+}
+
+@if (step() === 3) {
+    <app-admin-driver-registration-success-panel
+    (done)="done()"
+    />
+}
+
+</app-auth-card>

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/admin-driver-registration-page/admin-driver-registration-page.component.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/admin-driver-registration-page/admin-driver-registration-page.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminDriverRegistrationPageComponent } from './admin-driver-registration-page.component';
+
+describe('AdminDriverRegistrationPageComponent', () => {
+  let component: AdminDriverRegistrationPageComponent;
+  let fixture: ComponentFixture<AdminDriverRegistrationPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminDriverRegistrationPageComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AdminDriverRegistrationPageComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/admin-driver-registration-page/admin-driver-registration-page.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/admin-driver-registration-page/admin-driver-registration-page.component.ts
@@ -1,0 +1,140 @@
+import { Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators, FormGroup } from '@angular/forms';
+
+import { AuthCardComponent } from '../../auth/components/auth-card/auth-card.component';
+
+import { AdminDriverRegistrationDriverPanelComponent } from '../components/admin-driver-registration-driver-panel/admin-driver-registration-driver-panel.component';
+import { AdminDriverRegistrationVehiclePanelComponent } from '../components/admin-driver-registration-vehicle-panel/admin-driver-registration-vehicle-panel.component';
+import { AdminDriverRegistrationSuccessPanelComponent } from '../components/admin-driver-registration-success-panel/admin-driver-registration-success-panel.component';
+
+import { DriverService } from '../services/driver.service';
+import { ToastService } from '../../../shared/components/toast/toast.service';
+import { DriverCreateDTO } from '../../../shared/models/driver.models';
+
+type Step = 1 | 2 | 3;
+
+@Component({
+  selector: 'app-admin-driver-registration-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    AuthCardComponent,
+    AdminDriverRegistrationDriverPanelComponent,
+    AdminDriverRegistrationVehiclePanelComponent,
+    AdminDriverRegistrationSuccessPanelComponent,
+  ],
+  templateUrl: './admin-driver-registration-page.component.html',
+  styleUrls: ['./admin-driver-registration-page.component.css'],
+})
+export class AdminDriverRegistrationPageComponent {
+  step = signal<Step>(1);
+  creating = signal(false);
+
+  driverForm: FormGroup;
+  vehicleForm: FormGroup;
+
+  private selectedProfileImage: File | null = null;
+
+  constructor(
+    private fb: FormBuilder,
+    private driverService: DriverService,
+    private toast: ToastService
+  ) {
+    this.driverForm = this.fb.group({
+      firstName: ['', [Validators.required, Validators.minLength(2), Validators.maxLength(50), Validators.pattern(/^[^\d]+$/)]],
+      lastName: ['', [Validators.required, Validators.minLength(2), Validators.maxLength(50), Validators.pattern(/^[^\d]+$/)]],
+      address: ['', [Validators.required, Validators.minLength(5), Validators.maxLength(100)]],
+      city: ['', [Validators.required, Validators.minLength(2), Validators.maxLength(50)]],
+      phoneNumber: ['', [Validators.required, Validators.pattern(/^\+?\d{7,15}$/)]],
+      email: ['', [Validators.required, Validators.email]],
+      profilePhoto: [null],
+    });
+
+    this.vehicleForm = this.fb.group({
+      model: ['', [Validators.required, Validators.minLength(2), Validators.maxLength(60)]],
+      type: ['STANDARD', [Validators.required]],
+      licencePlate: ['', [Validators.required, Validators.pattern(/^[A-ZČĆŠĐŽ]{1,3}-\d{2,4}-[A-ZČĆŠĐŽ]{1,3}$/)]],
+      seatCount: ['', [Validators.required, Validators.pattern(/^\d+$/), Validators.min(1), Validators.max(8)]],
+      petFriendly: [false],
+      babyFriendly: [false],
+    });
+
+    this.driverForm.get('profilePhoto')?.valueChanges.subscribe((v: File | null) => {
+      this.selectedProfileImage = v instanceof File ? v : null;
+    });
+  }
+
+  goNextFromDriver() {
+    this.driverForm.markAllAsTouched();
+    if (this.driverForm.invalid) return;
+    this.step.set(2);
+  }
+
+  goBackToDriver() {
+    this.step.set(1);
+  }
+
+  createDriver() {
+    this.vehicleForm.markAllAsTouched();
+    if (this.vehicleForm.invalid) return;
+
+    const dto: DriverCreateDTO = {
+      firstName: String(this.driverForm.value.firstName ?? ''),
+      lastName: String(this.driverForm.value.lastName ?? ''),
+      address: String(this.driverForm.value.address ?? ''),
+      city: String(this.driverForm.value.city ?? ''),
+      phoneNumber: String(this.driverForm.value.phoneNumber ?? ''),
+      email: String(this.driverForm.value.email ?? ''),
+      profileImageUrl: null,
+      vehicle: {
+        model: String(this.vehicleForm.value.model ?? ''),
+        type: this.vehicleForm.value.type,
+        licencePlate: String(this.vehicleForm.value.licencePlate ?? ''),
+        seatCount: Number(this.vehicleForm.value.seatCount ?? 0),
+        babyFriendly: !!this.vehicleForm.value.babyFriendly,
+        petFriendly: !!this.vehicleForm.value.petFriendly,
+      },
+    };
+
+    this.creating.set(true);
+
+    this.driverService.registerDriver(dto, this.selectedProfileImage).subscribe({
+      next: () => {
+        this.creating.set(false);
+        this.step.set(3);
+      },
+      error: (err) => {
+        this.creating.set(false);
+        const msg =
+          err?.error?.message ||
+          (typeof err?.error === 'string' ? err.error : null) ||
+          'Driver registration failed.';
+        this.toast.show(msg);
+      },
+    });
+  }
+
+  done() {
+    this.driverForm.reset({
+      firstName: '',
+      lastName: '',
+      address: '',
+      city: '',
+      phoneNumber: '',
+      email: '',
+      profilePhoto: null,
+    });
+    this.vehicleForm.reset({
+      model: '',
+      type: 'STANDARD',
+      licencePlate: '',
+      seatCount: '',
+      petFriendly: false,
+      babyFriendly: false,
+    });
+    this.selectedProfileImage = null;
+    this.step.set(1);
+  }
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-driver-panel/admin-driver-registration-driver-panel.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-driver-panel/admin-driver-registration-driver-panel.component.css
@@ -1,0 +1,85 @@
+.adr-form{
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.adr-form--wide{
+  width: min(860px, 100%);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  column-gap: 70px;
+  row-gap: 12px;
+  margin: 0 auto;
+}
+
+.adr-col{
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.adr-field{
+  width: min(320px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.adr-label{
+  font-size: var(--fs-lg);
+  font-weight: var(--weight-regular);
+}
+
+.adr-input{
+  height: 36px;
+  border-radius: 6px;
+  border: none;
+  outline: none;
+  background: var(--color-white);
+  color: var(--color-text);
+  padding: 0 14px;
+  box-sizing: border-box;
+}
+
+.file-input{
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  color: #999;
+}
+
+.file-input.has-file{
+  color: var(--color-text);
+}
+
+.adr-actions{
+  display: flex;
+  justify-content: right;
+  font-size: var(--fs-lg);
+  margin-top: 15px;
+  margin-bottom: -30px;
+}
+
+@media (max-width: 900px){
+  .adr-form--wide{
+    grid-template-columns: 1fr;
+    column-gap: 0;
+
+    justify-items: center;
+  }
+
+  .adr-col{
+    width: 100%;
+    align-items: center;
+  }
+
+  .adr-field{
+    width: min(320px, 100%);
+  }
+
+  .adr-actions{
+    justify-content: center; /* ili flex-end ako hoćeš desno */
+  }
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-driver-panel/admin-driver-registration-driver-panel.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-driver-panel/admin-driver-registration-driver-panel.component.html
@@ -1,0 +1,71 @@
+<form class="adr-form adr-form--wide" [formGroup]="form" autocomplete="off">
+  <div class="adr-col">
+    <div class="adr-field">
+      <label class="adr-label text-semibold">Firstname</label>
+      <input class="adr-input text-medium" type="text" formControlName="firstName" />
+      @if (isInvalid('firstName')) {
+        <div class="form-error">2–50 characters. No numbers.</div>
+      }
+    </div>
+
+    <div class="adr-field">
+      <label class="adr-label text-semibold">Lastname</label>
+      <input class="adr-input text-medium" type="text" formControlName="lastName" />
+      @if (isInvalid('lastName')) {
+        <div class="form-error">2–50 characters. No numbers.</div>
+      }
+    </div>
+
+    <div class="adr-field">
+      <label class="adr-label text-semibold">Address (Street and number)</label>
+      <input class="adr-input text-medium" type="text" formControlName="address" />
+      @if (isInvalid('address')) {
+        <div class="form-error">Address is required (5–100 chars).</div>
+      }
+    </div>
+
+    <div class="adr-field">
+      <label class="adr-label text-semibold">City</label>
+      <input class="adr-input text-medium" type="text" formControlName="city" />
+      @if (isInvalid('city')) {
+        <div class="form-error">City is required (2–50 chars).</div>
+      }
+    </div>
+  </div>
+
+  <div class="adr-col">
+    <div class="adr-field">
+      <label class="adr-label text-semibold">Phone number</label>
+      <input class="adr-input text-medium" type="text" formControlName="phoneNumber" />
+      @if (isInvalid('phoneNumber')) {
+        <div class="form-error">Use digits only (optionally +), 7–15 digits.</div>
+      }
+    </div>
+
+    <div class="adr-field">
+      <label class="adr-label text-semibold">Email</label>
+      <input class="adr-input text-medium" type="email" formControlName="email" />
+      @if (isInvalid('email')) {
+        <div class="form-error">
+          @if (c('email').hasError('required')) { Email is required. }
+          @else if (c('email').hasError('email')) { Enter a valid email. }
+        </div>
+      }
+    </div>
+
+    <div class="adr-field">
+      <label class="adr-label text-semibold">Profile photo</label>
+
+      <label class="adr-input file-input text-medium" [class.has-file]="c('profilePhoto').value">
+        {{ c('profilePhoto').value?.name || 'Upload photo' }}
+        <input type="file" accept="image/*" (change)="onFileSelected($event)" hidden />
+      </label>
+    </div>
+  </div>
+</form>
+
+<div card-actions class="adr-actions">
+  <button type="button" class="btn btn--primary btn-scale text-semibold" (click)="next.emit()">
+    Next
+  </button>
+</div>

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-driver-panel/admin-driver-registration-driver-panel.component.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-driver-panel/admin-driver-registration-driver-panel.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminDriverRegistrationDriverPanelComponent } from './admin-driver-registration-driver-panel.component';
+
+describe('AdminDriverRegistrationDriverPanelComponent', () => {
+  let component: AdminDriverRegistrationDriverPanelComponent;
+  let fixture: ComponentFixture<AdminDriverRegistrationDriverPanelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminDriverRegistrationDriverPanelComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AdminDriverRegistrationDriverPanelComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-driver-panel/admin-driver-registration-driver-panel.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-driver-panel/admin-driver-registration-driver-panel.component.ts
@@ -1,0 +1,29 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-admin-driver-registration-driver-panel',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './admin-driver-registration-driver-panel.component.html',
+  styleUrls: ['./admin-driver-registration-driver-panel.component.css'],
+})
+export class AdminDriverRegistrationDriverPanelComponent {
+  @Input({ required: true }) form!: FormGroup;
+  @Output() next = new EventEmitter<void>();
+
+  c(name: string) { return this.form.get(name)!; }
+
+  isInvalid(name: string) {
+    const ctrl = this.c(name);
+    return ctrl.invalid && (ctrl.touched || ctrl.dirty);
+  }
+
+  onFileSelected(ev: Event) {
+    const input = ev.target as HTMLInputElement;
+    const file = input.files?.[0] ?? null;
+    this.form.patchValue({ profilePhoto: file });
+    this.form.get('profilePhoto')?.markAsTouched();
+  }
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-success-panel/admin-driver-registration-success-panel.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-success-panel/admin-driver-registration-success-panel.component.css
@@ -1,0 +1,24 @@
+.adr-success{
+  width: min(520px, 100%);
+  margin: 0 auto;
+}
+
+.adr-success__title{
+  font-size: var(--fs-h1);
+  color: rgba(255,255,255,0.95);
+  margin-bottom: 12px;
+}
+
+.adr-success__text{
+  font-size: var(--fs-md);
+  color: rgba(255,255,255,0.9);
+  line-height: 1.25;
+}
+
+.adr-success__actions{
+  display: flex;
+  justify-content: right;
+  margin-top: 22px;
+  margin-bottom: -35px;
+  font-size: var(--fs-lg);
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-success-panel/admin-driver-registration-success-panel.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-success-panel/admin-driver-registration-success-panel.component.html
@@ -1,0 +1,13 @@
+<div class="adr-success">
+  <div class="adr-success__title text-regular">Driver account created</div>
+
+  <div class="adr-success__text text-regular">
+    An activation email has been sent to the driver.
+  </div>
+
+  <div card-actions class="adr-success__actions">
+    <button type="button" class="btn btn--primary btn-scale text-semibold" (click)="done.emit()">
+      Done
+    </button>
+  </div>
+</div>

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-success-panel/admin-driver-registration-success-panel.component.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-success-panel/admin-driver-registration-success-panel.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminDriverRegistrationSuccessPanelComponent } from './admin-driver-registration-success-panel.component';
+
+describe('AdminDriverRegistrationSuccessPanelComponent', () => {
+  let component: AdminDriverRegistrationSuccessPanelComponent;
+  let fixture: ComponentFixture<AdminDriverRegistrationSuccessPanelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminDriverRegistrationSuccessPanelComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AdminDriverRegistrationSuccessPanelComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-success-panel/admin-driver-registration-success-panel.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-success-panel/admin-driver-registration-success-panel.component.ts
@@ -1,0 +1,13 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-admin-driver-registration-success-panel',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './admin-driver-registration-success-panel.component.html',
+  styleUrls: ['./admin-driver-registration-success-panel.component.css'],
+})
+export class AdminDriverRegistrationSuccessPanelComponent {
+  @Output() done = new EventEmitter<void>();
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-vehicle-panel/admin-driver-registration-vehicle-panel.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-vehicle-panel/admin-driver-registration-vehicle-panel.component.css
@@ -1,0 +1,74 @@
+.avr-form{
+  width: min(480px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: 10px;
+}
+
+.auth-card--wide .card-panel{
+  width: min(520px, 92vw);
+}
+
+.avr-col{
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.avr-field{
+  width: min(400px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.avr-label{
+  font-size: var(--fs-lg);
+}
+
+.avr-input{
+  height: 36px;
+  border-radius: 6px;
+  border: none;
+  outline: none;
+  background: var(--color-white);
+  color: var(--color-text);
+  padding: 0 14px;
+  box-sizing: border-box;
+}
+
+.avr-check-row{
+  margin-top: 5px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.avr-check{
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--color-white);
+  font-size: var(--fs-lg);
+}
+
+.avr-check input{
+  width: 20px;
+  height: 20px;
+  accent-color: var(--color-secondary);
+}
+
+.avr-actions{
+  display: flex;
+  justify-content: right;
+  font-size: var(--fs-lg);
+  gap: 14px;
+  margin-top: 15px;
+  margin-bottom: -30px;
+}
+
+@media (max-width: 900px){
+  .avr-actions{
+    justify-content: flex-end;
+  }
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-vehicle-panel/admin-driver-registration-vehicle-panel.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-vehicle-panel/admin-driver-registration-vehicle-panel.component.html
@@ -1,0 +1,62 @@
+<form class="avr-form" [formGroup]="form" autocomplete="off">
+  <div class="avr-col">
+    <div class="avr-field">
+      <label class="avr-label text-semibold">Model</label>
+      <input class="avr-input text-medium" type="text" formControlName="model" />
+      @if (isInvalid('model')) {
+        <div class="form-error">Model is required.</div>
+      }
+    </div>
+
+    <div class="avr-field">
+      <label class="avr-label text-semibold">Type</label>
+      <select class="avr-input text-medium" formControlName="type">
+        <option value="STANDARD">Standard</option>
+        <option value="VAN">Van</option>
+        <option value="LUXURY">Luxury</option>
+      </select>
+      @if (isInvalid('type')) {
+        <div class="form-error">Type is required.</div>
+      }
+    </div>
+
+    <div class="avr-field">
+      <label class="avr-label text-semibold">License plate</label>
+      <input class="avr-input text-medium" type="text" formControlName="licencePlate" placeholder="NS-123-AB" />
+      @if (isInvalid('licencePlate')) {
+        <div class="form-error">Format example: NS-123-AB</div>
+      }
+    </div>
+
+    <div class="avr-field">
+      <label class="avr-label text-semibold">Number of seats</label>
+      <input class="avr-input text-medium" type="text" formControlName="seatCount" />
+      @if (isInvalid('seatCount')) {
+        <div class="form-error">Seats must be a whole number (1–8).</div>
+      }
+    </div>
+
+    <div class="avr-check-row">
+      <label class="avr-check text-semibold">
+        <input type="checkbox" formControlName="petFriendly" />
+        <span>Pet friendly</span>
+      </label>
+
+      <label class="avr-check text-semibold">
+        <input type="checkbox" formControlName="babyFriendly" />
+        <span>Child seat available</span>
+      </label>
+    </div>
+  </div>
+</form>
+
+<div card-actions class="avr-actions">
+  <button type="button" class="btn btn--ghost text-semibold btn-scale" (click)="back.emit()" [disabled]="creating">
+    Back
+  </button>
+
+  <button type="button" class="btn btn--primary text-semibold btn-scale" (click)="create.emit()" [disabled]="creating">
+    @if (!creating) { Create }
+    @else { Creating... }
+  </button>
+</div>

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-vehicle-panel/admin-driver-registration-vehicle-panel.component.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-vehicle-panel/admin-driver-registration-vehicle-panel.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminDriverRegistrationVehiclePanelComponent } from './admin-driver-registration-vehicle-panel.component';
+
+describe('AdminDriverRegistrationVehiclePanelComponent', () => {
+  let component: AdminDriverRegistrationVehiclePanelComponent;
+  let fixture: ComponentFixture<AdminDriverRegistrationVehiclePanelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminDriverRegistrationVehiclePanelComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(AdminDriverRegistrationVehiclePanelComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-vehicle-panel/admin-driver-registration-vehicle-panel.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/components/admin-driver-registration-vehicle-panel/admin-driver-registration-vehicle-panel.component.ts
@@ -1,0 +1,25 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-admin-driver-registration-vehicle-panel',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './admin-driver-registration-vehicle-panel.component.html',
+  styleUrls: ['./admin-driver-registration-vehicle-panel.component.css'],
+})
+export class AdminDriverRegistrationVehiclePanelComponent {
+  @Input({ required: true }) form!: FormGroup;
+  @Input() creating = false;
+
+  @Output() back = new EventEmitter<void>();
+  @Output() create = new EventEmitter<void>();
+
+  c(name: string) { return this.form.get(name)!; }
+
+  isInvalid(name: string) {
+    const ctrl = this.c(name);
+    return ctrl.invalid && (ctrl.touched || ctrl.dirty);
+  }
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/services/driver.service.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/services/driver.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DriverService } from './driver.service';
+
+describe('DriverService', () => {
+  let service: DriverService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DriverService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/features/add-driver/services/driver.service.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/add-driver/services/driver.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { DriverCreateDTO, DriverResponseDTO } from '../../../shared/models/driver.models';
+
+@Injectable({ providedIn: 'root' })
+export class DriverService {
+  private readonly API = 'http://localhost:8081/api/drivers';
+
+  constructor(private http: HttpClient) {}
+
+  registerDriver(dto: DriverCreateDTO, profileImage?: File | null): Observable<DriverResponseDTO> {
+    const fd = new FormData();
+    fd.append('data', new Blob([JSON.stringify(dto)], { type: 'application/json' }));
+
+    if (profileImage) {
+      fd.append('profileImage', profileImage, profileImage.name);
+    }
+
+    return this.http.post<DriverResponseDTO>(this.API, fd);
+  }
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/auth/auth.routes.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/auth/auth.routes.ts
@@ -8,6 +8,7 @@ import { SuccessfulRegistrationComponent } from './pages/successful-registration
 import { ActivationComponent } from './components/activation/activation.component';
 import { ForgotPasswordMessageComponent } from './pages/forgot-password-message/forgot-password-message.component';
 import { GuestGuard } from '../../core/auth/guards/guest.guard';
+import { DriverActivationPageComponent } from './pages/driver-activation-page/driver-activation-page.component';
 
 export const AUTH_ROUTES: Routes = [
   { path: 'login', component: LoginComponent, canActivate: [GuestGuard] },
@@ -17,5 +18,6 @@ export const AUTH_ROUTES: Routes = [
   { path: 'register-passenger', component: PassengerRegistrationComponent, canActivate: [GuestGuard] },
   { path: 'successful-registration', component: SuccessfulRegistrationComponent },
   { path: 'forgot-password-message', component: ForgotPasswordMessageComponent},
-  { path: 'activation', component: ActivationComponent }
+  { path: 'activation', component: ActivationComponent },
+  { path: 'driver-activation', component: DriverActivationPageComponent }
 ];

--- a/frontend/komsiluk-taxiProject/src/app/features/auth/components/auth-card/auth-card.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/auth/components/auth-card/auth-card.component.ts
@@ -7,5 +7,8 @@ import { Component, Input } from '@angular/core';
   styleUrl: './auth-card.component.css',
 })
 export class AuthCardComponent {
+
+  constructor() {}
+
   @Input() title!: string;
 }

--- a/frontend/komsiluk-taxiProject/src/app/features/auth/pages/driver-activation-page/driver-activation-page.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/features/auth/pages/driver-activation-page/driver-activation-page.component.css
@@ -1,0 +1,54 @@
+.da-form{
+  width: min(400px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.da-desc{
+  font-size: var(--fs-md);
+  opacity: 0.9;
+  margin-bottom: 20px;
+}
+
+.da-field{
+  width: min(360px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0 auto;
+}
+
+.da-label{
+  font-size: var(--fs-lg);
+  font-weight: var(--weight-regular);
+}
+
+.da-input{
+  height: 42px;
+  border-radius: 6px;
+  border: none;
+  outline: none;
+  background: var(--color-white);
+  color: var(--color-text);
+  padding: 0 16px;
+  box-sizing: border-box;
+}
+
+.da-actions{
+  display: flex;
+  justify-content: right;
+  margin-top: 20px;
+  margin-bottom: -30px;
+  font-size: var(--fs-lg);
+}
+
+.da-success{
+  text-align: left;
+  font-size: var(--fs-lg);
+}
+
+:host(.auth-card--narrow) .card-panel {
+  width: min(300px, 92vw);
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/auth/pages/driver-activation-page/driver-activation-page.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/features/auth/pages/driver-activation-page/driver-activation-page.component.html
@@ -1,0 +1,54 @@
+<app-auth-card title="Driver activation" class="auth-card--narrow">
+
+  @if (step() === 1) {
+    <form class="da-form" [formGroup]="form" (ngSubmit)="submit()" autocomplete="off">
+      <div class="da-desc text-regular">
+        Set your password to activate your driver account.
+      </div>
+
+      <div class="da-field">
+        <label class="da-label text-semibold">Password</label>
+        <input class="da-input text-medium" type="password" formControlName="password" />
+        @if (isInvalid('password')) {
+          <div class="form-error">Min 8 chars, at least 1 letter and 1 number.</div>
+        }
+      </div>
+
+      <div class="da-field">
+        <label class="da-label text-semibold">Repeat password</label>
+        <input class="da-input text-medium" type="password" formControlName="repeat" />
+        @if (isInvalid('repeat')) {
+          <div class="form-error">Repeat password is required.</div>
+        }
+        @if (mismatch()) {
+          <div class="form-error">Passwords do not match.</div>
+        }
+      </div>
+
+      <div class="da-actions">
+        <button
+          type="submit"
+          class="btn btn--primary btn-scale text-semibold"
+          [disabled]="loading()"
+        >
+          {{ loading() ? 'Activating...' : 'Activate' }}
+        </button>
+      </div>
+    </form>
+  }
+
+  @if (step() === 2) {
+    <ng-container>
+      <div class="da-success text-regular">
+        Your driver account has been successfully activated!
+      </div>
+    </ng-container>
+  }
+
+  @if (step() === 2) {
+    <button card-actions type="button" class="btn btn--primary btn-scale text-semibold" [routerLink]="'/login'">
+      Go to login
+    </button>
+  }
+
+</app-auth-card>

--- a/frontend/komsiluk-taxiProject/src/app/features/auth/pages/driver-activation-page/driver-activation-page.component.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/auth/pages/driver-activation-page/driver-activation-page.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DriverActivationPageComponent } from './driver-activation-page.component';
+
+describe('DriverActivationPageComponent', () => {
+  let component: DriverActivationPageComponent;
+  let fixture: ComponentFixture<DriverActivationPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DriverActivationPageComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DriverActivationPageComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/komsiluk-taxiProject/src/app/features/auth/pages/driver-activation-page/driver-activation-page.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/auth/pages/driver-activation-page/driver-activation-page.component.ts
@@ -1,0 +1,92 @@
+import { Component, OnInit, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+
+import { AuthCardComponent } from '../../components/auth-card/auth-card.component';
+import { AuthService } from '../../../../core/auth/services/auth.service';
+import { ToastService } from '../../../../shared/components/toast/toast.service';
+
+type Step = 1 | 2;
+
+@Component({
+  selector: 'app-driver-activation-page',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, AuthCardComponent],
+  templateUrl: './driver-activation-page.component.html',
+  styleUrls: ['./driver-activation-page.component.css']
+})
+export class DriverActivationPageComponent implements OnInit {
+  step = signal<Step>(1);
+  loading = signal(false);
+
+  token: string | null = null;
+
+  form: FormGroup;
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private fb: FormBuilder,
+    private auth: AuthService,
+    private toast: ToastService
+  ) {
+    this.form = this.fb.group({
+      password: ['', [Validators.required, Validators.minLength(8), Validators.pattern(/^(?=.*[A-Za-z])(?=.*\d).+$/)]],
+      repeat: ['', [Validators.required]],
+    });
+  }
+
+  ngOnInit(): void {
+    this.token = this.route.snapshot.queryParamMap.get('token');
+
+    if (!this.token) {
+      this.toast.show('Invalid activation link.');
+      this.router.navigate(['/activation-message']);
+      return;
+    }
+  }
+
+  c(name: string) {
+    return this.form.get(name)!;
+  }
+
+  isInvalid(name: string) {
+    const ctrl = this.c(name);
+    return ctrl.invalid && (ctrl.dirty || ctrl.touched);
+  }
+
+  mismatch(): boolean {
+    const p = this.c('password').value;
+    const r = this.c('repeat').value;
+    return !!p && !!r && p !== r;
+  }
+
+  submit() {
+    this.form.markAllAsTouched();
+    if (this.form.invalid || this.mismatch() || !this.token) return;
+
+    this.loading.set(true);
+
+    const password = String(this.c('password').value);
+
+    this.auth.activateDriver(this.token, password).subscribe({
+      next: () => {
+        this.loading.set(false);
+        this.step.set(2);
+
+        this.router.navigate([], {
+          queryParams: { token: null },
+          queryParamsHandling: 'merge',
+          replaceUrl: true
+        });
+      },
+      error: (err) => {
+        this.loading.set(false);
+        const msg = err?.error?.message || 'Activation link is invalid or expired.';
+        this.toast.show(msg);
+        this.router.navigate(['/activation-message']);
+      }
+    });
+  }
+}

--- a/frontend/komsiluk-taxiProject/src/app/shared/models/driver.models.ts
+++ b/frontend/komsiluk-taxiProject/src/app/shared/models/driver.models.ts
@@ -1,0 +1,29 @@
+import { VehicleCreateDTO, VehicleType } from "./profile.models";
+
+export type DriverCreateDTO = {
+  firstName: string;
+  lastName: string;
+  address: string;
+  city: string;
+  phoneNumber: string;
+  email: string;
+  profileImageUrl?: string | null;
+  vehicle: VehicleCreateDTO;
+};
+
+export type DriverResponseDTO = {
+  id: number;
+  email: string;
+  firstName: string;
+  lastName: string;
+  address: string;
+  city: string;
+  phoneNumber: string;
+  profileImageUrl: string;
+  active: boolean;
+  blocked: boolean;
+  createdAt: string;
+  role: string;
+  driverStatus: string;
+  vehicle: any;
+};

--- a/frontend/komsiluk-taxiProject/src/app/shared/models/profile.models.ts
+++ b/frontend/komsiluk-taxiProject/src/app/shared/models/profile.models.ts
@@ -10,6 +10,15 @@ export interface VehicleResponseDTO {
   petFriendly: boolean;
 }
 
+export interface VehicleCreateDTO {
+  model: string;
+  type: VehicleType;
+  licencePlate: string;
+  seatCount: number;
+  babyFriendly: boolean;
+  petFriendly: boolean;
+}
+
 export interface UserProfileResponseDTO {
   email: string;
   firstName: string;


### PR DESCRIPTION
Implements admin-side driver registration with vehicle details and profile photo upload, including new Angular components, services, and routing. Backend now supports multipart driver creation, sends activation emails, and exposes driver activation endpoint. Also adds frontend driver activation page for password setup.


Closes #92 
Closes #93 