### PR TITLE
Implementation of Admin Live Ride Tracking

### DIFF
--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/controllers/RideController.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/controllers/RideController.java
@@ -132,5 +132,12 @@ public class RideController {
         );
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/active/all")
+    public ResponseEntity<Collection<RideResponseDTO>> getAllActiveRides() {
+        Collection<RideResponseDTO> activeRides = rideService.getAllActiveRides();
+        return new ResponseEntity<>(activeRides, HttpStatus.OK);
+    }
+
 }
 

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/repositories/RideRepository.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/repositories/RideRepository.java
@@ -88,4 +88,7 @@ public interface RideRepository extends JpaRepository<Ride, Long> {
     AND (r.createdBy.id = :userId OR p.id = :userId)
 """)
     Optional<Ride> findActiveRideForPassenger(@Param("userId") Long userId);
+
+    @Query("SELECT r FROM Ride r WHERE r.status = rs.ac.uns.ftn.iss.Komsiluk.beans.enums.RideStatus.ACTIVE")
+    Collection<Ride> findAllActiveRides();
 }

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/RideService.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/RideService.java
@@ -804,4 +804,13 @@ public class RideService implements IRideService {
                 .map(rideDTOMapper::toActiveResponseDTO); // Samo pozoveš maper
     }
 
+    @Override
+    public Collection<RideResponseDTO> getAllActiveRides() {
+        // Pozivamo tvoj novi repository metod za status ACTIVE
+        return rideRepository.findAllActiveRides()
+                .stream()
+                .map(rideDTOMapper::toResponseDTO) // Koristimo tvoj postojeći maper
+                .collect(Collectors.toList());
+    }
+
 }

--- a/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/interfaces/IRideService.java
+++ b/backend/src/main/java/rs/ac/uns/ftn/iss/Komsiluk/services/interfaces/IRideService.java
@@ -42,4 +42,6 @@ public interface IRideService {
     public Collection<AdminRideHistoryDTO> getAdminRideHistoryForUser(Long userId, LocalDate from, LocalDate to, AdminRideSortBy sortBy);
 
     Optional<RidePassengerActiveDTO> getActiveRideForPassenger(Long userId);
+
+    public Collection<RideResponseDTO> getAllActiveRides();
 }

--- a/frontend/komsiluk-taxiProject/src/app/app.routes.ts
+++ b/frontend/komsiluk-taxiProject/src/app/app.routes.ts
@@ -22,6 +22,7 @@ import { AdminDriverChangeRequestsPageComponent } from './features/approve-edit/
 
 import { AdminDriverRegistrationPageComponent } from './features/add-driver/admin-driver-registration-page/admin-driver-registration-page.component';
 import { AdminPricingPageComponent } from './features/pricing-page/admin-pricing-page.component';
+import { AdminLiveRidesPageComponent } from './features/admin-live-ride/admin-live-rides-page/admin-live-rides-page.component';
 
 export const routes: Routes = [
 
@@ -105,6 +106,11 @@ export const routes: Routes = [
     data: { roles: [UserRole.ADMIN] }
   },
 
+  { path: 'admin/live-rides',
+     component: AdminLiveRidesPageComponent, 
+     canActivate: [authGuard, roleGuard], data: { roles: [UserRole.ADMIN] } 
+    },
+    
   // ===== AUTH (PUBLIC, lazy) =====
   {
     path: '',

--- a/frontend/komsiluk-taxiProject/src/app/core/layout/rightsidebar.component/rightsidebar.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/core/layout/rightsidebar.component/rightsidebar.component.html
@@ -48,7 +48,8 @@
         <a class="rightmenu__item" routerLink="/admin/ride-history">Ride history</a>
         <a class="rightmenu__item" routerLink="/panic-history">Panic history</a>
         <a class="rightmenu__item" routerLink="/admin/pricing">Price list</a>
-        <a class="rightmenu__item" routerLink="/driver-change-requests">Edit requests</a>
+        <a class="rightmenu__item" routerLink="/admin/live-rides">Live rides</a>
+
       </ng-container>
 
     </nav>

--- a/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-ride-card/admin-live-ride-card.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-ride-card/admin-live-ride-card.component.css
@@ -1,0 +1,91 @@
+:host {
+  display: block;
+  margin-bottom: 12px;
+}
+
+.ride-card {
+  display: grid;
+  grid-template-columns: 200px 1fr 200px;
+  gap: 20px;
+  background: rgba(0, 0, 0, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 16px 20px;
+  color: white;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  align-items: stretch;
+}
+
+.ride-card:hover {
+  background: rgba(0, 0, 0, 0.8);
+  border-color: #ffff00;
+}
+
+.ride-card__col--driver {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.ride-card__driver-label {
+  font-size: 10px;
+  color: #ffff00;
+  font-weight: 800;
+  letter-spacing: 1px;
+}
+
+.ride-card__driver-name {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 4px 0;
+}
+
+.ride-card__date { font-size: 12px; opacity: 0.6; }
+.ride-card__time-range { font-size: 14px; font-weight: 600; }
+
+/* RUTA */
+.ride-card__col--route {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.route-step { display: flex; align-items: center; gap: 10px; }
+.route-dot { width: 8px; height: 8px; border-radius: 50%; }
+.route-dot--start { background: #ffff00; }
+.route-dot--end { background: #ff4444; }
+.route-line { width: 1px; height: 15px; background: rgba(255,255,255,0.2); margin-left: 3.5px; }
+.route-label { font-size: 9px; opacity: 0.5; text-transform: uppercase; }
+.route-address { font-size: 13px; }
+
+/* TREĆA KOLONA */
+.ride-card__col--stats {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
+.ride-info-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: right;
+}
+
+.info-item { font-size: 12px; }
+.info-label { opacity: 0.6; margin-right: 5px; }
+.info-value { font-weight: 600; }
+.price-value { font-size: 17px; font-weight: 800; color: #ffff00; }
+
+.ride-card__details-btn {
+  background: #ffff00;
+  color: #111;
+  border: none;
+  border-radius: 20px;
+  padding: 6px 18px;
+  font-size: 11px;
+  font-weight: 800;
+  cursor: pointer;
+  margin-top: 10px;
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-ride-card/admin-live-ride-card.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-ride-card/admin-live-ride-card.component.html
@@ -1,0 +1,51 @@
+<div class="ride-card" (click)="onDetailsClick($event)">
+  
+  <div class="ride-card__col ride-card__col--driver">
+    <div class="ride-card__driver-label">DRIVER</div>
+    <div class="ride-card__driver-name">{{ ride().driverName }}</div>
+    <div class="ride-card__driver-label">{{ ride().date }}</div>
+    <div class="ride-card__driver-name">{{ ride().startTime }} - {{ ride().endTime }}</div>
+  </div>
+
+  <div class="ride-card__col ride-card__col--route">
+    <div class="route-step">
+      <div class="route-dot route-dot--start"></div>
+      <div class="route-text">
+        <span class="price-label">Pickup:</span>
+        <span class="price-value">{{ ride().pickup }}</span>
+      </div>
+    </div>
+    <div class="route-line"></div>
+    <div class="route-step">
+      <div class="route-dot route-dot--end"></div>
+      <div class="route-text">
+        <span class="price-label">Destination:</span>
+        <span class="price-value">{{ ride().destination }}</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="ride-card__col ride-card__col--stats">
+    <div class="ride-info-list">
+      <div class="info-item">
+        <span class="price-label">Distance:</span>
+        <span class="price-value">{{ ride().kilometers }} km</span>
+      </div>
+      <div class="info-item">
+        <span class="price-label">Duration:</span>
+        <span class="price-value">{{ ride().durationText }}</span>
+      </div>
+      <div class="info-item info-item--price">
+        <span class="price-label">Price:</span>
+        <span class="price-value">{{ ride().price }} $</span>
+      </div>
+    </div>
+
+    
+    <button class="ride-card__details-btn" (click)="onDetailsClick($event)">
+      DETAILS
+    </button>
+
+
+  </div>
+</div>

--- a/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-ride-card/admin-live-ride-card.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-ride-card/admin-live-ride-card.component.ts
@@ -1,0 +1,25 @@
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AdminLiveRideCard } from '../../../shared/models/admin-ride-view.models';
+@Component({
+  selector: 'app-admin-live-ride-card',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './admin-live-ride-card.component.html',
+  styleUrls: ['./admin-live-ride-card.component.css']
+})
+export class AdminLiveRideCardComponent {
+  ride = input.required<AdminLiveRideCard>();
+  selected = input<boolean>(false);
+  details = output<string>();
+
+  onDetailsClick(event: MouseEvent) {
+  event.stopPropagation();
+  
+  const rideId = this.ride().id;
+  console.log('Emitujem ID za detalje:', rideId);
+  
+  this.details.emit(rideId);
+}
+
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-rides-details-modal/admin-live-ride-details-modal.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-rides-details-modal/admin-live-ride-details-modal.component.css
@@ -1,0 +1,110 @@
+.rh-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: rgba(0,0,0,0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(4px);
+}
+
+.rh-modal__dialog {
+  width: min(1040px, 96vw);
+  background: rgba(0,0,0,0.92);
+  border: 3px solid var(--color-secondary);
+  border-radius: 10px;
+  box-shadow: 0 18px 60px rgba(0,0,0,0.7);
+  overflow: hidden;
+}
+
+.rh-modal__content {
+  display: grid;
+  grid-template-columns: 260px 1fr 320px;
+  gap: 18px;
+  padding: 20px;
+}
+
+.rh-title {
+  font-size: 14px;
+  font-weight: 800;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+  padding-bottom: 5px;
+}
+
+.rh-title--spaced { margin-top: 25px; }
+
+.rh-list { list-style: none; padding: 0; }
+.rh-list li { padding: 5px 0; border-bottom: 1px solid rgba(255,255,255,0.05); }
+
+.rh-map-container {
+  width: 100%;
+  height: 400px;
+  overflow: hidden;
+  border-radius: 12px;
+}
+
+/* Pregazi fiksnu visinu iz ride-details-map.component.css */
+.rh-map-container ::ng-deep .ride-details-map {
+  height: 100% !important;
+}
+.details-bottom-row {
+  display: flex;
+  justify-content: center;
+  margin-top: 15px;
+}
+
+.rh-info__row { margin-bottom: 12px; display: flex; flex-direction: column; }
+.rh-label { font-size: 11px; text-transform: uppercase; opacity: 0.9; }
+.rh-value { font-size: 14px; }
+
+.rh-stats {
+  margin-top: 25px;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.rh-stat { display: flex; align-items: center; gap: 10px; }
+
+.details-bottom-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 15px;
+  margin-top: 20px;
+  width: 100%;
+}
+
+.close-btn-komsiluk {
+  background: var(--color-secondary);
+  color: #111;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 40px;
+  font-weight: 800;
+  font-size: 14px;
+  cursor: pointer;
+  text-transform: uppercase;
+  transition: transform 0.2s ease;
+  width: fit-content; 
+}
+
+.close-btn-komsiluk:hover {
+  transform: scale(1.05);
+  background: #fff;
+}
+
+.stat-item-komsiluk {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 15px;
+}
+
+.rh-icon {
+  width: 22px;
+  height: 22px;
+  filter: invert(1);
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-rides-details-modal/admin-live-ride-details-modal.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-rides-details-modal/admin-live-ride-details-modal.component.html
@@ -1,0 +1,93 @@
+<div class="rh-modal" (click)="onClose()">
+  <div class="rh-modal__dialog" (click)="$event.stopPropagation()">
+    <div class="rh-modal__content">
+      
+      <section class="rh-left">
+        <h3 class="rh-title" style="color: white;">Driver:</h3>
+        <div class="driver-name-highlight" style="color: var(--color-secondary); font-weight: 800;">
+          {{ data.driverName }}
+        </div>
+
+        <h3 class="rh-title rh-title--spaced" style="color: white;">Passengers:</h3>
+        <ul class="rh-list">
+          @for (p of data.passengers; track p) {
+            <li style="color: var(--color-secondary); font-weight: 600;">{{ p }}</li>
+          } @empty {
+            <li style="color: rgba(255,255,255,0.5); font-style: italic;">No passengers for this ride.</li>
+          }
+        </ul>
+        
+      </section>
+
+      <section class="rh-center">
+        <app-ride-details-map 
+  [locations]="allLocations" 
+  [driverId]="data.driverId">
+</app-ride-details-map>
+        
+        <div class="details-bottom-container">
+          <div class="details-bottom-row">
+            <div class="details-bottom-item">
+              <span class="details-bottom-label" style="color: white;">Panic button pressed:</span>
+              <b class="details-bottom-value" [style.color]="data.panicPressed ? 'red' : 'var(--color-secondary)'">
+                {{ data.panicPressed ? 'YES' : 'NO' }}
+              </b>
+            </div>
+          </div>
+
+          <button class="close-btn-komsiluk" (click)="onClose()">CLOSE</button>
+        </div>
+      </section>
+
+     <section class="rh-right">
+  <h3 class="rh-title" style="color: white;">Route Details:</h3>
+  <div class="rh-info">
+    
+    <div class="rh-info__row">
+      <span class="rh-label" style="color: white;">Pickup location:</span>
+      <b class="rh-value" style="color: var(--color-secondary);">{{ data.pickupLocation }}</b>
+    </div>
+
+  @if (data.stops && data.stops.length > 0) {
+      @for (stop of data.stops; track $index) {
+        <div class="rh-info__row">
+          <span class="rh-label" style="color: white;">Stop {{ $index + 1 }}:</span>
+          <b class="rh-value" style="color: var(--color-secondary);">{{ stop }}</b>
+        </div>
+      }
+    }
+
+    <div class="rh-info__row">
+      <span class="rh-label" style="color: white;">Destination:</span>
+      <b class="rh-value" style="color: var(--color-secondary);">{{ data.destination }}</b>
+    </div>
+
+    <div class="rh-info__row" style="margin-top: 15px; border-top: 1px solid rgba(255,255,255,0.1); padding-top: 10px;">
+      <span class="rh-label" style="color: white;">Start time:</span>
+      <b class="rh-value" style="color: var(--color-secondary);">{{ data.startTime }}</b>
+    </div>
+    <div class="rh-info__row">
+      <span class="rh-label" style="color: white;">Est. End time:</span>
+      <b class="rh-value" style="color: var(--color-secondary);">{{ data.endTime }}</b>
+    </div>
+  </div>
+
+  <div class="rh-stats" style="margin-top: 20px;">
+    <div class="stat-item-komsiluk">
+      <span class="rh-label" style="color: white;">Distance:</span>
+      <b class="rh-value" style="color: var(--color-secondary);">{{ data.kilometers }} km</b>
+    </div>
+    <div class="stat-item-komsiluk">
+      <span class="rh-label" style="color: white;">Duration:</span>
+      <b class="rh-value" style="color: var(--color-secondary);">{{ data.durationText }}</b>
+    </div>
+    <div class="stat-item-komsiluk">
+      <span class="rh-label" style="color: white;">Price:</span>
+      <b class="rh-value" style="color: var(--color-secondary);">{{ data.price }} $</b>
+    </div>
+  </div>
+</section>
+
+    </div>
+  </div>
+</div>

--- a/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-rides-details-modal/admin-live-ride-details-modal.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-rides-details-modal/admin-live-ride-details-modal.component.ts
@@ -1,0 +1,59 @@
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RideService } from '../../../core/layout/components/passenger/book_ride/services/ride.service';
+import { RideDetailsMapComponent } from '../../driver-history/components/ride-details-map/ride-details-map.component';
+
+@Component({
+  selector: 'app-admin-live-ride-details-modal',
+  standalone: true,
+  imports: [CommonModule,RideDetailsMapComponent],
+  templateUrl: './admin-live-ride-details-modal.component.html',
+  styleUrl: './admin-live-ride-details-modal.component.css'
+})
+export class AdminLiveRideDetailsModalComponent implements OnInit, OnChanges {
+  @Input({ required: true }) data!: any;
+  @Output() close = new EventEmitter<void>();
+
+  private rideService = inject(RideService);
+  inconsistencyReports = signal<any[]>([]);
+
+ ngOnInit(): void {
+    this.checkAndLoad();
+  }
+
+  // OVO JE KLJUČNO: Ako se data promeni, ponovo učitaj reporte
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['data'] && this.data) {
+      console.log('MODAL PRIMIO PODATKE:', this.data);
+      console.log('VOZAČ ID ZA MAPU:', this.data.driverId);
+      this.checkAndLoad();
+    }
+  }
+
+  private checkAndLoad() {
+    if (this.data && this.data.id) {
+      console.log('Učitavam Inconsistencies za vožnju ID:', this.data.id);
+      this.loadInconsistencyReports();
+    }
+  }
+
+  loadInconsistencyReports() {
+    this.rideService.getInconsistencyReports(this.data.id).subscribe({
+      next: (reports) => {
+        this.inconsistencyReports.set(reports);
+      },
+      error: (err) => console.error('Error loading reports:', err)
+    });
+  }
+
+  get allLocations(): string[] {
+    if (!this.data) return [];
+    const validStops = (this.data.stops || []).filter((s: any) => !!s);
+    return [this.data.pickupLocation, ...validStops, this.data.destination];
+  }
+
+  onClose() {
+    this.close.emit();
+  }
+
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-rides-page/admin-live-rides-page.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-rides-page/admin-live-rides-page.component.css
@@ -1,0 +1,62 @@
+.history-page {
+  min-height: calc(100vh - 64px); 
+  padding: 18px 22px 26px;
+  box-sizing: border-box;
+}
+
+.history-page__container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.search-box {
+  margin-bottom: 20px;
+}
+
+.search-box input {
+  width: 100%;
+  padding: 14px 20px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.6);
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  color: white;
+  font-size: 16px;
+  transition: all 0.3s ease;
+}
+
+.search-box input:focus {
+  outline: none;
+  border-color: var(--color-secondary, #ffff00);
+  background: rgba(0, 0, 0, 0.8);
+  box-shadow: 0 0 10px rgba(255, 238, 2, 0.2);
+}
+
+.history-page__list {
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 10px;
+  min-height: 520px;
+  padding: 18px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: rgba(0, 0, 0, 0.35);
+}
+.ride-card__details-btn {
+  margin-top: auto; 
+  align-self: flex-end;
+  background: #ffff00;
+  color: #111;
+  border: none;
+  border-radius: 20px;
+  padding: 8px 20px;
+  font-size: 11px;
+  font-weight: 800;
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.ride-card__details-btn:hover {
+  transform: scale(1.05);
+  background: #ffffff;
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-rides-page/admin-live-rides-page.component.html
+++ b/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-rides-page/admin-live-rides-page.component.html
@@ -1,0 +1,33 @@
+<div class="history-page app-bg-textured"> 
+  <div class="history-page__container">
+    <h2 style="color: white; margin-bottom: 25px; text-align: center;">Live Active Rides</h2>
+
+    <div class="search-box" style="margin-bottom: 20px;">
+      <input
+        type="text"
+        [(ngModel)]="searchTerm"
+        (input)="onSearch()"
+        placeholder="Search by driver name or ID..."
+      />
+    </div>
+
+    <div class="history-page__list">
+      @for (r of filteredRides; track r.id) {
+        <app-admin-live-ride-card
+          [ride]="r"
+          [selected]="r.id === selectedRideId"
+          (details)="onDetails($event)">
+        </app-admin-live-ride-card>
+      } @empty {
+        <div style="color: white; text-align: center; padding: 40px;">No active rides at the moment.</div>
+      }
+    </div>
+  </div>
+</div>
+
+@if (detailsOpen && detailsVm) {
+  <app-admin-live-ride-details-modal
+    [data]="detailsVm"
+    (close)="detailsOpen = false">
+  </app-admin-live-ride-details-modal>
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-rides-page/admin-live-rides-page.component.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/admin-live-ride/admin-live-rides-page/admin-live-rides-page.component.ts
@@ -1,0 +1,172 @@
+import { Component, OnInit, inject, OnDestroy, ChangeDetectorRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { FormsModule } from '@angular/forms';
+import { interval, Subscription } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { AdminLiveRideCard, AdminLiveRideDetailsVm } from '../../../shared/models/admin-ride-view.models';
+import { AdminLiveRideCardComponent } from '../admin-live-ride-card/admin-live-ride-card.component';
+import { AdminLiveRideDetailsModalComponent } from '../admin-live-rides-details-modal/admin-live-ride-details-modal.component';
+import { DriverLocationService } from '../../../shared/components/map/services/driver-location.service';
+
+@Component({
+  selector: 'app-admin-live-rides-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule, AdminLiveRideCardComponent, AdminLiveRideDetailsModalComponent],
+  templateUrl: './admin-live-rides-page.component.html',
+  styleUrl: './admin-live-rides-page.component.css' 
+})
+export class AdminLiveRidesPageComponent implements OnInit, OnDestroy {
+  private http = inject(HttpClient);
+  private refreshSubscription: Subscription | undefined;
+  private cdr = inject(ChangeDetectorRef); 
+  private driverService = inject(DriverLocationService);
+
+  allActiveRides: AdminLiveRideCard[] = [];
+  filteredRides: AdminLiveRideCard[] = [];
+  searchTerm: string = '';
+
+  detailsOpen = false;
+  detailsVm: AdminLiveRideDetailsVm | null = null;
+  selectedRideId: string | null = null;
+    driversBasic: any;
+
+  ngOnInit() {
+    this.loadDriversAndStartPolling();
+  }
+
+  loadDriversAndStartPolling() {
+    this.driverService.getDriversBasic().subscribe({
+      next: (drivers) => {
+        this.driversBasic = drivers;
+        this.startAutoRefresh();
+      },
+      error: (err) => {
+        console.error('Greška pri učitavanju vozača:', err);
+        this.startAutoRefresh(); 
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    this.refreshSubscription?.unsubscribe();
+  }
+
+  startAutoRefresh() {
+    this.fetchActiveRides();
+    this.refreshSubscription = interval(10000) // Osvežava svakih 10 sekundi
+      .pipe(switchMap(() => this.http.get<any[]>('http://localhost:8081/api/rides/active/all')))
+      .subscribe({
+        next: (data) => {
+          this.allActiveRides = data.map(dto => this.mapToCard(dto));
+          this.onSearch();
+        },
+        error: (err) => console.error('Error fetching active rides:', err)
+      });
+  }
+
+fetchActiveRides() {
+  this.http.get<any[]>('http://localhost:8081/api/rides/active/all')
+    .subscribe({
+      next: (data) => {
+        this.allActiveRides = data.map(dto => this.mapToCard(dto));
+        this.onSearch(); 
+        this.cdr.detectChanges();
+      },
+      error: (err) => console.error(err)
+    });
+}
+
+
+  onSearch() {
+  const term = this.searchTerm.toLowerCase().trim();
+  
+  if (!term) {
+    this.filteredRides = [...this.allActiveRides];
+  } else {
+    this.filteredRides = this.allActiveRides.filter(r => 
+      r.driverName.toLowerCase().includes(term)
+    );
+  }
+}
+
+onDetails(rideId: string | number) {
+  this.selectedRideId = rideId.toString();
+  const card = this.allActiveRides.find(r => r.id === rideId.toString());
+
+  this.http.get<any>(`http://localhost:8081/api/rides/${Number(rideId)}`).subscribe({
+    next: (dto) => {
+      const emails: string[] = [];
+      if (dto.creatorEmail) emails.push(dto.creatorEmail);
+      if (dto.passengerEmails) emails.push(...dto.passengerEmails);
+
+      // REŠENJE ZA STANICE: Splitujemo string po karakteru '|'
+      let stopsArray: string[] = [];
+      if (dto.route?.stops && typeof dto.route.stops === 'string') {
+        stopsArray = dto.route.stops.split('|').map((s: string) => s.trim()).filter((s: string) => s.length > 0);
+      } else if (Array.isArray(dto.route?.stops)) {
+        stopsArray = dto.route.stops;
+      }
+
+      
+      let estimatedEndTime = 'Pending';
+    if (dto.startTime && dto.estimatedDurationMin) {
+    const start = new Date(dto.startTime);
+    // Dodajemo minute na startno vreme
+    const end = new Date(start.getTime() + dto.estimatedDurationMin * 60000);
+    estimatedEndTime = end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    }
+
+      this.detailsVm = {
+        id: dto.id,
+        driverId: dto.driverId || (card ? Number(card.driverId) : null),
+        driverName: card?.driverName || 'N/A',
+        driverEmail: dto.driverEmail || '',
+        vehicleType: dto.vehicleType || 'STANDARD',
+        status: dto.status,
+        passengers: emails,
+        
+        pickupLocation: dto.route?.startAddress || 'N/A', 
+        destination: dto.route?.endAddress || 'N/A',
+        stops: stopsArray, // Sada je ovo sigurno niz celih adresa
+        
+        kilometers: dto.distanceKm,
+        durationText: `${dto.estimatedDurationMin || 0} min`,
+        price: dto.price,
+        
+        panicPressed: dto.panicTriggered || false,
+        startTime: dto.startTime ? new Date(dto.startTime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : 'N/A',
+        endTime: estimatedEndTime
+    };
+      
+      this.detailsOpen = true;
+      this.cdr.detectChanges();
+    }
+  });
+}
+ private mapToCard(dto: any): AdminLiveRideCard {
+  const driverInfo = this.driversBasic.find((d: { id: any; }) => d.id === dto.driverId);
+  
+  const displayName = driverInfo 
+    ? `${driverInfo.firstName} ${driverInfo.lastName}` 
+    : (dto.driverEmail || `Driver #${dto.driverId}`);
+
+  return {
+    id: dto.id.toString(),
+    driverId: dto.driverId?.toString() || '',
+    driverName: displayName, 
+    date: 'LIVE',
+    startTime: dto.startTime ? new Date(dto.startTime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '--:--',
+    endTime: 'Pending',
+    pickup: dto.startAddress || 'N/A',
+    destination: dto.endAddress || 'N/A',
+    status: 'active',
+    passengers: dto.passengerEmails ? dto.passengerEmails.length : 0,
+    kilometers: dto.distanceKm || 0,
+    durationText: `${dto.estimatedDurationMin || 0} min`,
+    price: dto.price || 0,
+    mapImageUrl: 'assets/taxi.png'
+  };
+}
+
+}

--- a/frontend/komsiluk-taxiProject/src/app/features/driver-history/components/ride-details-map/ride-details-map.component.css
+++ b/frontend/komsiluk-taxiProject/src/app/features/driver-history/components/ride-details-map/ride-details-map.component.css
@@ -4,3 +4,34 @@
   border-radius: 12px;
   overflow: hidden;
 }
+
+/* ride-details-map.component.css */
+
+/* 1. Resetuj Leafletov default za našu ikonu */
+::ng-deep .km-custom-taxi-icon {
+  background: transparent !important;
+  border: none !important;
+}
+
+/* 2. Naša klasa za autić */
+::ng-deep .km-driver {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  border: 2px solid #000000 !important;
+  box-shadow: 0 4px 10px rgba(0,0,0,0) !important;
+  transition: all 0.2s ease;
+}
+
+/* 3. FORSIRAJ CRVENU */
+::ng-deep .km-driver--busy {
+  background: #ef4444 !important; /* Jaka crvena */
+}
+
+::ng-deep .km-driver__icon {
+  font-size: 18px;
+  color: rgb(0, 0, 0) !important;
+}
+

--- a/frontend/komsiluk-taxiProject/src/app/shared/components/map/services/driver-location.service.ts
+++ b/frontend/komsiluk-taxiProject/src/app/shared/components/map/services/driver-location.service.ts
@@ -29,4 +29,8 @@ updateLocation(driverId: number, lat: number, lng: number) {
   return this.http.put<void>(`${this.API}/${driverId}/location`, { lat, lng });
 }
 
+getOneDriverLocation(driverId: number): Observable<any> {
+    return this.http.get<any>(`${this.API}/${driverId}/location`);
+  }
+
 }

--- a/frontend/komsiluk-taxiProject/src/app/shared/models/admin-ride-view.models.ts
+++ b/frontend/komsiluk-taxiProject/src/app/shared/models/admin-ride-view.models.ts
@@ -1,0 +1,49 @@
+import { VehicleType } from "./profile.models"; // Pretpostavka da je VehicleType ovde
+
+export interface AdminLiveRideCard {
+  id: string;
+  driverId: string; // Dodali smo ID vozača za pretragu
+  driverName: string;
+  date: string; // npr. 'LIVE' ili 'Active since 12:30'
+  startTime: string;
+  endTime: string; // 'Pending' ili 'Expected XX:XX'
+  pickup: string;
+  destination: string;
+  status: 'active' | 'pending' | 'in-progress' | 'finished' | 'cancelled'; // Pojednostavljeni statusi za prikaz
+  passengers: number;
+  kilometers: number;
+  durationText: string;
+  price: number;
+  mapImageUrl: string;
+}
+
+export interface AdminLiveRideDetailsVm {
+  // Osnovno - ID mora biti Long (number) kao na backu
+  id: number;
+  driverId: number | null;
+  driverName: string;
+  driverEmail: string;
+  vehicleType: string;
+  status: string;
+
+  // PUTNICI - Promeni u string[] jer backend šalje emailove!
+  passengers: string[]; 
+
+  // RUTA - Koristi imena polja koja tvoj modal HTML već traži
+  pickupLocation: string; // Umesto startAddress
+  destination: string;    // Umesto endAddress
+  stops: string[];        // Waypoints/Stops sa backenda
+  currentAddress?: string;
+
+  // STATISTIKA
+  kilometers: number;
+  durationText: string;
+  price: number;
+
+  // PANIC & TIMES
+  panicPressed: boolean;
+  panicReason?: string;
+  startTime: string; // Umesto startedAt
+  endTime: string;   // Umesto finishedAt
+
+}


### PR DESCRIPTION
Introduce an Admin Live Rides view and backend support to list and monitor currently active rides. 
Backend: add GET /api/rides/active/all (ADMIN only), repository query findAllActiveRides(), and service method getAllActiveRides() + interface update. 
Frontend: add route and right sidebar link; new standalone components and assets for live rides page, ride card and details modal; new models file for admin ride view; periodic polling to /api/rides/active/all and detailed ride fetch for modal. Map & tracking: add getOneDriverLocation() to DriverLocationService and enhance ride-details-map to show/update a live driver marker. Various styles and template updates included.

Closes #127 
Closes #128 