### PR TITLE
Add rating tests on frontend

### DIFF
--- a/frontend/komsiluk-taxiProject/src/app/features/driver-history/services/rating.service.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/driver-history/services/rating.service.spec.ts
@@ -1,0 +1,108 @@
+import { TestBed } from '@angular/core/testing';
+import { RatingService, RatingCreateDTO, RatingResponseDTO } from './rating.service';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+describe('RatingService', () => {
+
+  let service: RatingService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+
+    service = TestBed.inject(RatingService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+
+  it('should send POST request to create rating', () => {
+
+    const rideId = 5;
+
+    const payload: RatingCreateDTO = {
+      driverGrade: 5,
+      vehicleGrade: 4,
+      comment: 'Great ride'
+    };
+
+    const mockResponse: RatingResponseDTO = {
+      id: 1,
+      rideId: 5,
+      raterId: 2,
+      raterMail: 'test@mail.com',
+      driverId: 10,
+      vehicleId: 20,
+      vehicleGrade: 4,
+      driverGrade: 5,
+      comment: 'Great ride',
+      createdAt: '2026-02-14T00:00:00'
+    };
+
+    service.createRating(rideId, payload).subscribe(response => {
+      expect(response).toEqual(mockResponse);
+    });
+
+    const req = httpMock.expectOne(`/api/rides/${rideId}/ratings`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(payload);
+
+    req.flush(mockResponse);
+  });
+
+  it('should fetch ratings for ride', () => {
+
+    const rideId = 7;
+
+    const mockResponse: RatingResponseDTO[] = [];
+
+    service.getRatingsForRide(rideId).subscribe(response => {
+      expect(response).toEqual(mockResponse);
+    });
+
+    const req = httpMock.expectOne(
+      `http://localhost:8081/api/rides/${rideId}/ratings`
+    );
+
+    expect(req.request.method).toBe('GET');
+
+    req.flush(mockResponse);
+  });
+
+  it('should fetch rating by rater id', () => {
+
+    const rideId = 3;
+    const raterId = 9;
+
+    const mockResponse: RatingResponseDTO = {
+      id: 2,
+      rideId: 3,
+      raterId: 9,
+      raterMail: 'rater@mail.com',
+      driverId: 1,
+      vehicleId: 1,
+      vehicleGrade: 5,
+      driverGrade: 5,
+      comment: 'Perfect',
+      createdAt: '2026-02-14T00:00:00'
+    };
+
+    service.getRatingForRideByRater(rideId, raterId).subscribe(response => {
+      expect(response).toEqual(mockResponse);
+    });
+
+    const req = httpMock.expectOne(
+      `/api/rides/${rideId}/ratings/${raterId}`
+    );
+
+    expect(req.request.method).toBe('GET');
+
+    req.flush(mockResponse);
+  });
+
+});

--- a/frontend/komsiluk-taxiProject/src/app/features/ride/components/driver-rating-modal/driver-raitng-modal.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/ride/components/driver-rating-modal/driver-raitng-modal.ts
@@ -45,14 +45,23 @@ export class DriverRatingModalComponent {
         this.toast.show(msg);
         this.close.emit();
       },
-      error: (err) => {
-        let msg = 'Failed to send rating.';
-        if (err?.error?.message) msg = err.error.message;
-        else if (err?.error) msg = err.error;
-        else if (err?.message) msg = err.message;
-        this.toast.show(String(msg));
-        this.close.emit();
-      }
+error: (err) => {
+  let msg = 'Failed to send rating.';
+
+  if (err?.error?.message) {
+    msg = err.error.message;
+  } 
+  else if (typeof err?.error === 'string' && err.error.trim() !== '') {
+    msg = err.error;
+  }
+  else if (err?.message) {
+    msg = err.message;
+  }
+
+  this.toast.show(msg);
+  this.close.emit();
+}
+
     });
   }
 }

--- a/frontend/komsiluk-taxiProject/src/app/features/ride/components/driver-rating-modal/driver-rating-modal.spec.ts
+++ b/frontend/komsiluk-taxiProject/src/app/features/ride/components/driver-rating-modal/driver-rating-modal.spec.ts
@@ -1,0 +1,202 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DriverRatingModalComponent } from './driver-raitng-modal';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ToastService } from '../../../../shared/components/toast/toast.service';
+
+describe('DriverRatingModalComponent', () => {
+
+  let component: DriverRatingModalComponent;
+  let fixture: ComponentFixture<DriverRatingModalComponent>;
+  let httpMock: HttpTestingController;
+  let toastMock: jasmine.SpyObj<ToastService>;
+
+  beforeEach(async () => {
+
+    toastMock = jasmine.createSpyObj('ToastService', ['show']);
+
+    await TestBed.configureTestingModule({
+      imports: [
+        DriverRatingModalComponent,
+        HttpClientTestingModule
+      ],
+      providers: [
+        { provide: ToastService, useValue: toastMock }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DriverRatingModalComponent);
+    component = fixture.componentInstance;
+
+    component.rideId = 1;
+    component.raterId = 2;
+
+    httpMock = TestBed.inject(HttpTestingController);
+
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should append component to document body on init', () => {
+    const appendSpy = spyOn(document.body, 'appendChild').and.callThrough();
+    component.ngOnInit();
+    expect(appendSpy).toHaveBeenCalled();
+  });
+
+  describe('initial state', () => {
+
+    it('should create component', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('submit button should be disabled when grades are not selected', () => {
+      component.driverGrade = 0;
+      component.vehicleGrade = 0;
+      fixture.detectChanges();
+
+      const button: HTMLButtonElement =
+        fixture.nativeElement.querySelector('.btn-submit');
+
+      expect(button.disabled).toBeTrue();
+    });
+
+    it('submit button should be enabled when both grades are selected', () => {
+      component.driverGrade = 4;
+      component.vehicleGrade = 5;
+      fixture.detectChanges();
+
+      const button: HTMLButtonElement =
+        fixture.nativeElement.querySelector('.btn-submit');
+
+      expect(button.disabled).toBeFalse();
+    });
+
+  });
+
+  describe('submit success flow', () => {
+
+    beforeEach(() => {
+      component.driverGrade = 5;
+      component.vehicleGrade = 4;
+      component.comment = 'Excellent ride';
+      fixture.detectChanges();
+    });
+
+    it('should call correct endpoint with correct payload', () => {
+
+      component.submit();
+
+      const req = httpMock.expectOne(
+        'http://localhost:8081/api/rides/1/ratings'
+      );
+
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({
+        raterId: 2,
+        vehicleGrade: 4,
+        driverGrade: 5,
+        comment: 'Excellent ride'
+      });
+
+      req.flush({});
+    });
+
+    it('should emit submitted and close and show success toast', () => {
+
+      spyOn(component.submitted, 'emit');
+      spyOn(component.close, 'emit');
+
+      component.submit();
+
+      const req = httpMock.expectOne(
+        'http://localhost:8081/api/rides/1/ratings'
+      );
+
+      req.flush({ id: 123 });
+
+      expect(component.submitted.emit).toHaveBeenCalledTimes(1);
+      expect(component.close.emit).toHaveBeenCalledTimes(1);
+      expect(toastMock.show)
+        .toHaveBeenCalledWith('Rating submitted successfully.');
+    });
+
+  });
+
+  describe('submit error flow', () => {
+
+    beforeEach(() => {
+      component.driverGrade = 3;
+      component.vehicleGrade = 3;
+      fixture.detectChanges();
+    });
+
+    it('should show backend message when provided', () => {
+
+      spyOn(component.close, 'emit');
+
+      component.submit();
+
+      const req = httpMock.expectOne(
+        'http://localhost:8081/api/rides/1/ratings'
+      );
+
+      req.flush(
+        { message: 'Custom backend error' },
+        { status: 400, statusText: 'Bad Request' }
+      );
+
+      expect(toastMock.show)
+        .toHaveBeenCalledWith('Custom backend error');
+
+      expect(component.close.emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fallback to err.message when backend does not provide message', () => {
+
+      spyOn(component.close, 'emit');
+
+      component.submit();
+
+      const req = httpMock.expectOne(
+        'http://localhost:8081/api/rides/1/ratings'
+      );
+
+      req.error(new ErrorEvent('Network error'));
+
+      expect(toastMock.show).toHaveBeenCalled();
+
+      const calledArg = toastMock.show.calls.mostRecent().args[0];
+      expect(calledArg).toContain('Http failure response');
+
+      expect(component.close.emit).toHaveBeenCalledTimes(1);
+    });
+
+  });
+
+  describe('UI interaction', () => {
+
+    it('should update driverGrade when driver star is clicked', () => {
+
+      const stars = fixture.nativeElement.querySelectorAll('.star');
+
+      stars[4].click();
+      fixture.detectChanges();
+
+      expect(component.driverGrade).toBeGreaterThan(0);
+    });
+
+    it('should update vehicleGrade when vehicle star is clicked', () => {
+
+      const stars = fixture.nativeElement.querySelectorAll('.star');
+
+      stars[9].click();
+      fixture.detectChanges();
+
+      expect(component.vehicleGrade).toBeGreaterThan(0);
+    });
+
+  });
+
+});

--- a/frontend/komsiluk-taxiProject/tsconfig.spec.json
+++ b/frontend/komsiluk-taxiProject/tsconfig.spec.json
@@ -5,7 +5,7 @@
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
     "types": [
-      "jasmine",
+      "jasmine"
     ]
   },
   "include": [


### PR DESCRIPTION
Add unit tests for rating flows and the driver rating modal: new specs cover RatingService (createRating, getRatingsForRide, getRatingForRideByRater) and DriverRatingModalComponent (initial state, submit success/error flows, DOM interactions).

Closes #175